### PR TITLE
Fix ROI utility API mismatch

### DIFF
--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -20,7 +20,7 @@ from PySide6.QtCore import Qt
 class EveBot:
     def __init__(self, model_path=None):
         # Initialize environment, agent, UI, and FSM
-        self.env = EveEnv(max_actions=None)
+        self.env = EveEnv()
         self.agent = AIPilot(model_path=model_path)
         self.ui = Ui()
         self.fsm = FSM()

--- a/src/ui.py
+++ b/src/ui.py
@@ -48,7 +48,9 @@ class Ui:
             self.load_capture_region(command['region_name'])
 
     def load_capture_region(self, region_name, yaml_path='regions.yaml'):
-        region = self.region_handler.load(region_name, yaml_path)
+        if yaml_path != self.region_handler.yaml_path:
+            self.region_handler = RegionHandler(yaml_path)
+        region = self.region_handler.load(region_name)
         if region:
             self.capture_region = region
             self.region_handler.validate(self.capture_region, save_preview=True, region_name=region_name)


### PR DESCRIPTION
## Summary
- correct EveEnv initialization in `EveBot`
- expose `get_type`, `get_coords` and `validate` helpers in `RegionHandler`
- fix ROI screenshot message
- allow `Ui.load_capture_region` to load from alternate YAML path

## Testing
- `python -m py_compile src/roi_capture.py src/ui.py src/bot_core.py`
- `python test_env.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6847f4351c888322bd25dd2f736fa69d