### PR TITLE
Fix EveEnv initialization

### DIFF
--- a/data_recorder.py
+++ b/data_recorder.py
@@ -7,7 +7,7 @@ from src.env import EveEnv
 
 
 def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True):
-    env = EveEnv(max_actions=10)
+    env = EveEnv()
     demo_buffer = []
 
     mode = "manual" if manual else "automatic"

--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -20,7 +20,7 @@ from PySide6.QtCore import Qt
 class EveBot:
     def __init__(self, model_path=None):
         # Initialize environment, agent, UI, and FSM
-        self.env = EveEnv(max_actions=None)
+        self.env = EveEnv()
         self.agent = AIPilot(model_path=model_path)
         self.ui = Ui()
         self.fsm = FSM()


### PR DESCRIPTION
## Summary
- remove deprecated `max_actions` argument from data recording
- remove deprecated `max_actions` argument from bot core

## Testing
- `python test_env.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6847fdcdb93483229dc5be7c1fff21a1