### PR TITLE
Add configurable tesseract path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ The ``MiningActions`` class implements the sequence of recommended mining
 steps defined in *Scaffold.md*. It provides helpers for warping to asteroid
 belts, approaching targets and performing human-like idle behaviour. See
 ``src/mining_actions.py`` for the full list of methods.
+
+## Generating Box Files
+
+Use `generate_box_files.py` to create `.box` files for Tesseract training:
+
+```bash
+python generate_box_files.py -i training_texts_dir/images -b training_texts_dir/box
+```
+
+If Tesseract is not on your `PATH`, provide the path via `--tesseract-cmd` or
+set the `TESSERACT_CMD` environment variable.

--- a/generate_box_files.py
+++ b/generate_box_files.py
@@ -9,7 +9,7 @@ import subprocess
 import argparse
 import shutil
 import pytesseract
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+
 
 def main():
     """
@@ -34,10 +34,13 @@ def main():
     parser.add_argument(
         "--tesseract-cmd", "-t",
         type=str,
-        default=None,
-        help="Path to the tesseract executable (defaults to your PATH)"
+        default=os.environ.get("TESSERACT_CMD"),
+        help="Path to the tesseract executable (or set TESSERACT_CMD env var; defaults to your PATH)"
     )
     args = parser.parse_args()
+
+    if args.tesseract_cmd:
+        pytesseract.pytesseract.tesseract_cmd = args.tesseract_cmd
 
     # Determine tesseract command
     tess_cmd = args.tesseract_cmd or shutil.which("tesseract")


### PR DESCRIPTION
## Summary
- make tesseract path configurable via CLI or `TESSERACT_CMD` env var
- describe new environment variable in README

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6848240b69888322ac0e0d4429a5ce3f