### PR TITLE
Improve asteroid targeting OCR

### DIFF
--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -1,4 +1,4 @@
-# version: 0.5.0
+# version: 0.5.1
 # path: src/bot_core.py
 
 import sys
@@ -134,13 +134,16 @@ class EveBot:
                 self.log("↕️ Sorting overview by distance")
                 time.sleep(0.5)
 
-            # Click first asteroid row
-            box = self.rh.load("overview_panel")
-            if box:
-                x1, y1, x2, y2 = box
-                pyautogui.click(x1 + 40, y1 + 15)
-                self.log("🪨 Selected nearest asteroid")
-                time.sleep(0.5)
+            # Select asteroid using OCR fallback to first row
+            if self.mining.target_asteroid_via_ocr():
+                self.log("🪨 Selected asteroid via OCR")
+            else:
+                box = self.rh.load("overview_panel")
+                if box:
+                    x1, y1, x2, y2 = box
+                    pyautogui.click(x1 + 40, y1 + 15)
+                    self.log("🪨 Selected nearest asteroid")
+                    time.sleep(0.5)
 
             self.mining.approach_asteroid()
             self.mining.human_like_idle()

--- a/src/mining_actions.py
+++ b/src/mining_actions.py
@@ -1,4 +1,4 @@
-# version: 0.1.0
+# version: 0.1.1
 # path: src/mining_actions.py
 """High level mining routine utilities.
 
@@ -83,6 +83,23 @@ class MiningActions:
             x1, y1, x2, y2 = box
             pyautogui.click((x1 + x2) // 2, (y1 + y2) // 2)
             self._sleep(1.0)
+
+    def target_asteroid_via_ocr(self):
+        """Scan the overview for an asteroid entry using OCR and click it."""
+        panel = self.rh.load("overview_panel")
+        if not panel:
+            return False
+
+        x1, y1, x2, y2 = panel
+        screen = capture_utils.capture_screen(select_region=False)
+        crop = screen[y1:y2, x1:x2]
+        pos = self.cv.find_asteroid_entry(crop)
+        if pos:
+            cx, cy = pos
+            pyautogui.click(x1 + cx, y1 + cy)
+            self._sleep(0.5)
+            return True
+        return False
 
     def activate_mining_lasers(self):
         slots = ["module_slot1", "module_slot2", "module_slot3"]


### PR DESCRIPTION
## Summary
- enhance CvEngine `find_asteroid_entry` to support more ores and fuzzy matching
- add `target_asteroid_via_ocr` helper in mining actions
- use OCR targeting in bot core

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485c585ab88322b5fc042ca0922879