### PR TITLE
Fix run_start imports and adjust headless tests

### DIFF
--- a/run_start.py
+++ b/run_start.py
@@ -3,6 +3,10 @@
 
 import os
 import argparse
+import sys
+
+# Ensure local src modules are importable when running directly
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.monitor import Monitor


### PR DESCRIPTION
## Summary
- make `run_start.py` add `src` to `sys.path` so standalone runs work
- patch `test_env.py` to stub out GUI and OCR modules for testing in headless environments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486499969483229b1ebc9053367266