### PR TITLE
Fix EveEnv NameError in bot_core

### DIFF
--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -13,6 +13,9 @@ from ocr import OcrEngine
 from cv import CvEngine
 from state_machine import FSM, Event
 from mining_actions import MiningActions
+from env import EveEnv
+from agent import AIPilot
+from ui import Ui
 
 class EveBot:
     def __init__(self, model_path=None):


### PR DESCRIPTION
## Summary
- import `EveEnv`, `AIPilot`, and `Ui` in `src/bot_core.py`

This resolves the `NameError: EveEnv is not defined` when running `bot_core.py` directly.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68486a75ea9c8322994a1ee05a88a3b3