### PR TITLE
Enable ROI selection via cv2 and add unit test

### DIFF
--- a/src/capture_utils.py
+++ b/src/capture_utils.py
@@ -1,4 +1,4 @@
-# version: 0.7.0
+# version: 0.8.0
 # path: src/capture_utils.py
 
 import cv2
@@ -35,7 +35,19 @@ def capture_screen(select_region=False, window_title="EVE - CitizenZero"):
 
     if win32gui is None:
         # headless fallback for tests
-        return np.zeros((10, 10, 3), dtype=np.uint8)
+        img = np.zeros((10, 10, 3), dtype=np.uint8)
+        if select_region:
+            roi = cv2.selectROI("Select Region", img, showCrosshair=True, fromCenter=False)
+            if hasattr(cv2, "destroyWindow"):
+                try:
+                    cv2.destroyWindow("Select Region")
+                except Exception:
+                    pass
+            x, y, w, h = roi
+            if w == 0 or h == 0:
+                return None
+            return (x, y, x + w, y + h)
+        return img
 
     try:
         (left, top, right, bottom), hwnd = get_window_rect(window_title)
@@ -79,7 +91,21 @@ def capture_screen(select_region=False, window_title="EVE - CitizenZero"):
     mfc_dc.DeleteDC()
     win32gui.ReleaseDC(hwnd, hwnd_dc)
 
-    return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+    img_bgr = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+
+    if select_region:
+        roi = cv2.selectROI("Select Region", img_bgr, showCrosshair=True, fromCenter=False)
+        if hasattr(cv2, "destroyWindow"):
+            try:
+                cv2.destroyWindow("Select Region")
+            except Exception:
+                pass
+        x, y, w, h = roi
+        if w == 0 or h == 0:
+            return None
+        return (x, y, x + w, y + h)
+
+    return img_bgr
 
 # --- Test directly ---
 if __name__ == "__main__":

--- a/tests/test_capture_utils.py
+++ b/tests/test_capture_utils.py
@@ -1,0 +1,34 @@
+import sys
+import importlib
+import types
+import os
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Prepare dummy modules to avoid real GUI dependencies
+cv2_mod = types.ModuleType('cv2')
+cv2_called = {}
+
+def fake_selectROI(winname, img, showCrosshair=True, fromCenter=False):
+    cv2_called['img_shape'] = img.shape
+    return (1, 2, 3, 4)
+
+cv2_mod.selectROI = fake_selectROI
+cv2_mod.destroyWindow = lambda name: None
+
+sys.modules['cv2'] = cv2_mod
+sys.modules['win32gui'] = None
+sys.modules['win32ui'] = None
+sys.modules['win32con'] = None
+
+if 'capture_utils' in sys.modules:
+    del sys.modules['capture_utils']
+import capture_utils
+importlib.reload(capture_utils)
+
+def test_select_region_returns_coords():
+    coords = capture_utils.capture_screen(select_region=True)
+    assert coords == (1, 2, 4, 6)
+    assert cv2_called['img_shape'] == (10, 10, 3)
+


### PR DESCRIPTION
## Summary
- add OpenCV ROI selection option to `capture_screen`
- return ROI coordinates when a region is selected
- cover new behaviour in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684922d0e7b88322aa3211c9269ffd25