### PR TITLE
Fix ROI overlay capture call

### DIFF
--- a/src/roi_live_overlay.py
+++ b/src/roi_live_overlay.py
@@ -18,7 +18,7 @@ def main_loop():
     print("[Overlay] Press ESC to exit")
 
     while True:
-        screen = capture_screen(overlay_title="ROI Live Overlay")
+        screen = capture_screen()
         if screen is None:
             print("[Overlay] ❌ Screen capture failed.")
             continue


### PR DESCRIPTION
## Summary
- remove unsupported `overlay_title` argument from ROI overlay screen capture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684923d7f1d48322bb43008450e79f87