### PR TITLE
Switch to PaddleOCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ set the `TESSERACT_CMD` environment variable. Windows users can run
 
 ### OCR Configuration
 
-`OcrEngine` also respects the `TESSERACT_CMD` variable or a `tesseract_cmd`
-argument when instantiated:
+`OcrEngine` uses [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) for
+text recognition. Once the package is installed no additional configuration is
+required:
 
 ```python
 from ocr import OcrEngine
-ocr = OcrEngine(tesseract_cmd="/usr/local/bin/tesseract")
+ocr = OcrEngine()
 ```

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -77,7 +77,7 @@ BAgent/
 ## Requirements
 
 ```txt
-pytesseract
+paddleocr
 opencv-python
 PySide6
 numpy

--- a/generate_box_files.py
+++ b/generate_box_files.py
@@ -8,7 +8,6 @@ import glob
 import subprocess
 import argparse
 import shutil
-import pytesseract
 
 
 def main():
@@ -39,8 +38,6 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.tesseract_cmd:
-        pytesseract.pytesseract.tesseract_cmd = args.tesseract_cmd
 
     # Determine tesseract command
     tess_cmd = args.tesseract_cmd or shutil.which("tesseract")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pillow
 pyautogui
-pytesseract
+paddleocr
 opencv-python
 PySide6
 gym

--- a/src/mining_actions.py
+++ b/src/mining_actions.py
@@ -14,7 +14,6 @@ import random
 import time
 import yaml
 import pyautogui
-import pytesseract
 
 from ui import Ui
 from roi_capture import RegionHandler
@@ -60,13 +59,13 @@ class MiningActions:
 
         full = capture_utils.capture_screen(select_region=False)
         panel = full[y1:y2, x1:x2]
-        data = pytesseract.image_to_data(panel, output_type=pytesseract.Output.DICT)
-        for i, txt in enumerate(data["text"]):
-            if txt.strip() == bookmark:
-                bx = x1 + data["left"][i]
-                by = y1 + data["top"][i]
-                bw = data["width"][i]
-                bh = data["height"][i]
+        data = self.ocr.extract_data(panel)
+        for entry in data:
+            if entry["text"].strip() == bookmark:
+                bx = x1 + entry["left"]
+                by = y1 + entry["top"]
+                bw = entry["width"]
+                bh = entry["height"]
                 pyautogui.click(bx + bw // 2, by + bh // 2)
                 break
 
@@ -171,13 +170,13 @@ class MiningActions:
 
         full = capture_utils.capture_screen(select_region=False)
         panel = full[y1:y2, x1:x2]
-        data = pytesseract.image_to_data(panel, output_type=pytesseract.Output.DICT)
-        for i, txt in enumerate(data["text"]):
-            if txt.strip() == station:
-                bx = x1 + data["left"][i]
-                by = y1 + data["top"][i]
-                bw = data["width"][i]
-                bh = data["height"][i]
+        data = self.ocr.extract_data(panel)
+        for entry in data:
+            if entry["text"].strip() == station:
+                bx = x1 + entry["left"]
+                by = y1 + entry["top"]
+                bw = entry["width"]
+                bh = entry["height"]
                 pyautogui.click(bx + bw // 2, by + bh // 2)
                 break
 

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,9 +1,8 @@
 # version: 0.3.5
 # path: src/ocr.py
 
-import os
 import numpy as np
-from PIL import Image, ImageGrab
+from PIL import Image
 import threading
 import queue
 
@@ -15,23 +14,11 @@ except Exception:
     _has_paddle = False
 
 class OcrEngine:
-    def __init__(self, use_angle_cls=True, lang='en', use_paddle=True, tesseract_cmd=None):
-        """
-        Initialize OCR engine: try PaddleOCR if available and requested, else use pytesseract.
-        """
-        self.use_paddle = use_paddle and _has_paddle
-        if self.use_paddle:
-            self.ocr = PaddleOCR(use_angle_cls=use_angle_cls, lang=lang)
-        # Dynamically import pytesseract to avoid pandas import at top-level
-        try:
-            import pytesseract
-            self.pytesseract = pytesseract
-            t_cmd = tesseract_cmd or os.environ.get("TESSERACT_CMD")
-            if t_cmd:
-                self.pytesseract.pytesseract.tesseract_cmd = t_cmd
-            self.has_tesseract = True
-        except Exception:
-            self.has_tesseract = False
+    def __init__(self, use_angle_cls=True, lang='en'):
+        """Initialize the PaddleOCR engine."""
+        if not _has_paddle:
+            raise ImportError("PaddleOCR is not installed")
+        self.ocr = PaddleOCR(use_angle_cls=use_angle_cls, lang=lang)
         # Setup threading queues
         self.task_queue = queue.Queue()
         self.result_queue = queue.Queue()
@@ -40,28 +27,43 @@ class OcrEngine:
         self.worker_thread.start()
 
     def extract_text(self, img):
-        """
-        Extract text from image using selected OCR engine.
-        """
-        if isinstance(img, np.ndarray):
-            pil_img = Image.fromarray(img)
+        """Extract text from an image."""
+        if isinstance(img, Image.Image):
+            arr = np.array(img)
         else:
-            pil_img = img
-        # Use PaddleOCR if available
-        if self.use_paddle:
-            arr = np.array(pil_img)
-            result = self.ocr.ocr(arr, cls=True)
-            lines = []
-            for line in result[0]:
-                text, conf = line[1]
-                if conf > 0.5:
-                    lines.append(text)
-            return '\n'.join(lines)
-        # Fallback to pytesseract if available
-        if self.has_tesseract:
-            return self.pytesseract.image_to_string(pil_img)
-        # No OCR available
-        return ""
+            arr = img
+        result = self.ocr.ocr(arr, cls=True)
+        lines = []
+        for line in result[0]:
+            text, conf = line[1]
+            if conf > 0.5:
+                lines.append(text)
+        return '\n'.join(lines)
+
+    def extract_data(self, img, conf_threshold=0.5):
+        """Return OCR results with bounding boxes similar to pytesseract."""
+        if isinstance(img, Image.Image):
+            arr = np.array(img)
+        else:
+            arr = img
+        result = self.ocr.ocr(arr, cls=True)
+        boxes = []
+        for line in result[0]:
+            box, (text, conf) = line
+            if conf < conf_threshold:
+                continue
+            xs = [pt[0] for pt in box]
+            ys = [pt[1] for pt in box]
+            left, top = min(xs), min(ys)
+            width, height = max(xs) - left, max(ys) - top
+            boxes.append({
+                'text': text,
+                'left': int(left),
+                'top': int(top),
+                'width': int(width),
+                'height': int(height)
+            })
+        return boxes
 
     def extract_text_batch(self, images):
         """


### PR DESCRIPTION
## Summary
- add `paddleocr` to requirements and update docs
- replace all uses of pytesseract with PaddleOCR
- drop pytesseract setup from scripts
- update OCR engine to rely on PaddleOCR
- update tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849267c720c8322b4951e38157e325e