### PR TITLE
Add model-aware session replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ python pre_train_data.py --demos demo_buffer.pkl --out bc_model.pt
 python run_start.py --train --bc_model bc_model.pt --timesteps 50000
 ```
 
+## Session Replay
+
+Visualize recorded demonstrations and compare against a trained model using
+`replay_session.py`:
+
+```bash
+python replay_session.py --log recordings/log.jsonl --delay 300 \
+    --model bc_model.pt --accuracy-out acc.json
+```
+
+During playback the actual action, predicted action and key state values are
+overlaid on the frame. Mismatched predictions are highlighted in red and the
+overall accuracy is written to the optional output file. Press **q** to exit the
+viewer.
+
 ## Mining Helpers
 
 The ``MiningActions`` class implements the sequence of recommended mining

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -29,6 +29,7 @@ BAgent/
 ├── export_ocr_samples.py # version: 0.1.0 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.0 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.1.0 | path: pre_train_data.py
+├── replay_session.py     # version: 0.2.0 | path: replay_session.py
 ├── add_tesseract_to_path.bat # helper script to set PATH on Windows
 ├── ets.txt               # sample training commands
 ├── promts.txt            # project prompts and notes

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -4,13 +4,69 @@
 import pickle
 import random
 import os
+import json
+from datetime import datetime
+import cv2
+from pynput import mouse, keyboard
+from threading import Event
 from src.env import EveEnv
 from stable_baselines3 import PPO
+
+
+def _map_click(env, x, y):
+    for idx, (typ, target) in enumerate(env.actions):
+        if typ == 'click':
+            coords = env.region_handler.get_coords(target)
+            if coords and coords[0] <= x <= coords[2] and coords[1] <= y <= coords[3]:
+                return idx, f'click_{target}'
+    return None, None
+
+
+def _map_key(env, key_name):
+    for idx, (typ, target) in enumerate(env.actions):
+        if typ == 'keypress' and key_name == target:
+            return idx, f'keypress_{target}'
+    return None, None
+
+
+def _wait_for_event(env):
+    """Block until a relevant mouse or keyboard event occurs."""
+    result = {}
+    done = Event()
+
+    def on_click(x, y, button, pressed):
+        if pressed and not done.is_set():
+            idx, label = _map_click(env, x, y)
+            if idx is not None:
+                result['data'] = (idx, label)
+                done.set()
+                return False
+
+    def on_press(key):
+        if done.is_set():
+            return False
+        try:
+            name = key.char.lower()
+        except AttributeError:
+            name = key.name.lower()
+        idx, label = _map_key(env, name)
+        if idx is not None:
+            result['data'] = (idx, label)
+            done.set()
+            return False
+
+    with mouse.Listener(on_click=on_click) as ml, keyboard.Listener(on_press=on_press) as kl:
+        done.wait()
+    ml.stop()
+    kl.stop()
+    return result['data']
 
 
 def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_path=None):
     env = EveEnv()
     demo_buffer = []
+    os.makedirs('recordings/frames', exist_ok=True)
+    log_path = os.path.join('recordings', 'log.jsonl')
     model = None
     if model_path and os.path.exists(model_path):
         model = PPO.load(model_path, env=env)
@@ -19,23 +75,38 @@ def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_
     print(f"Starting {mode} data recording for {num_samples} samples...")
     obs = env.reset()
 
-    for i in range(num_samples):
-        if manual:
-            action = int(input(f"Step {i+1}/{num_samples} - Enter action (0 to {env.action_space.n - 1}): "))
-        elif model:
-            action, _ = model.predict(obs, deterministic=True)
-            action = int(action)
-        else:
-            action = random.randint(0, env.action_space.n - 1)
-        obs, reward, done, info = env.step(action)
-        demo_buffer.append((obs, action))
-        print(f"Recorded: Step={i+1}, Action={action}, Reward={reward}")
-        if done:
-            obs = env.reset()
+    with open(log_path, 'a') as log_file:
+        for i in range(num_samples):
+            if manual:
+                idx, label = _wait_for_event(env)
+                action = idx
+            elif model:
+                action, _ = model.predict(obs, deterministic=True)
+                action = int(action)
+                label = f"model_{action}"
+            else:
+                action = random.randint(0, env.action_space.n - 1)
+                label = f"random_{action}"
+
+            frame = env.ui.capture()
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            fp = os.path.join('recordings/frames', f"{ts}.png")
+            cv2.imwrite(fp, frame)
+            state = {
+                'obs': obs.tolist(),
+                'prev_volume': getattr(env, 'prev_volume', None),
+                'cargo_capacity': getattr(env, 'cargo_capacity', None)
+            }
+            log_file.write(json.dumps({'frame': fp, 'action': label, 'state': state}) + "\n")
+
+            obs, reward, done, info = env.step(action)
+            demo_buffer.append((obs, action))
+            print(f"Recorded: Step={i+1}, Action={label}, Reward={reward}")
+            if done:
+                obs = env.reset()
 
     with open(filename, 'wb') as f:
         pickle.dump(demo_buffer, f)
-
     print(f"Data recording complete. Saved to {filename}")
 
 

--- a/replay_session.py
+++ b/replay_session.py
@@ -1,0 +1,142 @@
+import argparse
+import json
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+import torch
+
+from pre_train_data import BCModel
+from src.env import EveEnv
+from stable_baselines3 import PPO
+
+
+def _label_from_idx(env: EveEnv, idx: int) -> str:
+    """Return the semantic label for a given action index."""
+    typ, target = env.actions[idx]
+    if typ == "click":
+        return f"click_{target}"
+    if typ == "keypress":
+        return f"keypress_{target}"
+    return "sleep"
+
+
+def _label_to_idx(env: EveEnv, label: str) -> Optional[int]:
+    """Map a log label back to an action index."""
+    for idx, (typ, target) in enumerate(env.actions):
+        l = _label_from_idx(env, idx)
+        if label == l:
+            return idx
+    if "_" in label:
+        try:
+            return int(label.split("_")[-1])
+        except ValueError:
+            return None
+    return None
+
+
+def load_model(path: str, env: EveEnv) -> Tuple[object, str]:
+    """Load a PPO or BC model depending on file extension."""
+    if path.endswith(".pt"):
+        model = BCModel(env.observation_space.shape[0], env.action_space.n)
+        state = torch.load(path, map_location="cpu")
+        model.load_state_dict(state)
+        model.eval()
+        return model, "bc"
+    model = PPO.load(path, env=env)
+    return model, "ppo"
+
+
+def _predict(model, model_type: str, obs: np.ndarray) -> Tuple[int, float]:
+    """Return predicted action index and confidence."""
+    if model_type == "bc":
+        with torch.no_grad():
+            tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
+            logits = model(tensor)
+            probs = torch.softmax(logits, dim=1)
+            idx = int(torch.argmax(probs, dim=1).item())
+            conf = float(probs[0, idx].item())
+            return idx, conf
+    idx, _ = model.predict(obs, deterministic=True)
+    return int(idx), 1.0
+
+
+def replay(log_file: str, delay: int = 500, model_path: Optional[str] = None,
+           accuracy_out: Optional[str] = None):
+    """Display frames from a recorded session with optional model comparison."""
+    env = EveEnv()
+    model = None
+    model_type = ""
+    if model_path:
+        model, model_type = load_model(model_path, env)
+
+    correct = 0
+    total = 0
+
+    with open(log_file, "r") as f:
+        for line in f:
+            entry = json.loads(line)
+            frame = cv2.imread(entry["frame"])
+            if frame is None:
+                continue
+            label = entry.get("action", "")
+            state = entry.get("state", {})
+
+            y = 20
+            cv2.putText(frame, f"Actual: {label}", (10, y),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 1)
+
+            if model and "obs" in state:
+                pred_idx, conf = _predict(model, model_type,
+                                          np.array(state["obs"],
+                                                   dtype=np.float32))
+                pred_label = _label_from_idx(env, pred_idx)
+                total += 1
+                actual_idx = _label_to_idx(env, label)
+                if actual_idx is not None and actual_idx == pred_idx:
+                    correct += 1
+                    color = (0, 200, 0)
+                else:
+                    color = (0, 0, 255)
+                y += 20
+                msg = f"Pred: {pred_label} ({conf:.2f})"
+                cv2.putText(frame, msg, (10, y), cv2.FONT_HERSHEY_SIMPLEX,
+                            0.6, color, 1)
+
+            for k, v in state.items():
+                if k == "obs":
+                    continue
+                y += 20
+                cv2.putText(frame, f"{k}: {v}", (10, y),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 0), 1)
+
+            cv2.imshow("Replay", frame)
+            key = cv2.waitKey(delay)
+            if key & 0xFF == ord("q"):
+                break
+
+    cv2.destroyAllWindows()
+
+    if model and accuracy_out:
+        acc = correct / total if total else 0.0
+        with open(accuracy_out, "w") as f_out:
+            json.dump({"accuracy": acc}, f_out)
+        print(f"Accuracy: {acc:.2%}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replay recorded session")
+    parser.add_argument("--log", type=str, default="recordings/log.jsonl",
+                        help="Path to log file")
+    parser.add_argument("--delay", type=int, default=500,
+                        help="Delay between frames in ms")
+    parser.add_argument("--model", type=str, default=None,
+                        help="Optional path to PPO or BC model")
+    parser.add_argument("--accuracy-out", type=str, default=None,
+                        help="Write model accuracy to this file")
+    args = parser.parse_args()
+    replay(args.log, args.delay, args.model, args.accuracy_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gym
 stable-baselines3
 torch
 pyyaml
+pynput

--- a/tests/test_replay_session.py
+++ b/tests/test_replay_session.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import json
+import types
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_replay_writes_accuracy(tmp_path, monkeypatch):
+    log_file = tmp_path / 'log.jsonl'
+    frame_file = tmp_path / 'frame.png'
+    log_file.write_text(json.dumps({
+        'frame': str(frame_file),
+        'action': 'click_btn',
+        'state': {'obs': [0.0, 0.0], 'foo': 1}
+    }) + '\n')
+
+    cv2_mod = types.ModuleType('cv2')
+    calls = []
+    cv2_mod.imread = lambda p: calls.append(('imread', p)) or 'img'
+    cv2_mod.putText = lambda *a, **k: calls.append(('text', a[1]))
+    cv2_mod.imshow = lambda *a, **k: calls.append(('show',))
+    cv2_mod.waitKey = lambda d: calls.append(('wait', d)) or ord('q')
+    cv2_mod.destroyAllWindows = lambda: calls.append(('destroy',))
+    cv2_mod.FONT_HERSHEY_SIMPLEX = 0
+    monkeypatch.setitem(sys.modules, 'cv2', cv2_mod)
+
+    # dummy torch and sb3 before importing replay_session
+    sys.modules['torch'] = types.ModuleType('torch')
+    sb3_mod = types.ModuleType('stable_baselines3')
+    sb3_mod.PPO = type('PPO', (), {'load': classmethod(lambda cls, p, env=None: object())})
+    sys.modules['stable_baselines3'] = sb3_mod
+    # stub pre_train_data and env modules to avoid heavy deps
+    pre_mod = types.ModuleType('pre_train_data')
+    pre_mod.BCModel = object
+    sys.modules['pre_train_data'] = pre_mod
+    env_mod = types.ModuleType('src.env')
+    env_mod.EveEnv = object
+    sys.modules['src.env'] = env_mod
+
+    import replay_session
+
+    class DummyEnv:
+        def __init__(self):
+            self.actions = [('click', 'btn')]
+            self.action_space = types.SimpleNamespace(n=1)
+            self.observation_space = types.SimpleNamespace(shape=(2,))
+    monkeypatch.setattr(replay_session, 'EveEnv', DummyEnv)
+
+    class DummyModel:
+        def predict(self, obs, deterministic=True):
+            return 0, None
+    monkeypatch.setattr(replay_session, 'load_model', lambda p, env: (DummyModel(), 'ppo'))
+
+    acc_file = tmp_path / 'acc.json'
+    replay_session.replay(str(log_file), delay=1, model_path='m.zip', accuracy_out=str(acc_file))
+
+    assert ('imread', str(frame_file)) in calls
+    assert acc_file.exists()
+    data = json.loads(acc_file.read_text())
+    assert data['accuracy'] == 1.0
+    assert calls[-1] == ('destroy',)


### PR DESCRIPTION
## Summary
- enhance `replay_session.py` to show predicted actions and compute accuracy
- document replay comparison mode in README
- bump `replay_session.py` version in scaffold
- test replay accuracy recording

## Testing
- `pip install -q numpy pyyaml gym`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68493d2c713c8322a878d9e5645b8053