### PR TITLE
Update recorder and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # BAgent
+<!-- version: 0.4.2 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -16,7 +17,7 @@ pytest -q
 
 ## Behavior Cloning Pretraining
 
-1. Record demonstrations:
+1. Record demonstrations (frames + state logs saved under `logs/demonstrations/`):
 
 ```bash
 python data_recorder.py --manual False
@@ -40,7 +41,7 @@ Visualize recorded demonstrations and compare against a trained model using
 `replay_session.py`:
 
 ```bash
-python replay_session.py --log recordings/log.jsonl --delay 300 \
+python replay_session.py --log logs/demonstrations/log.jsonl --delay 300 \
     --model bc_model.pt --accuracy-out acc.json
 ```
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -25,7 +25,7 @@ BAgent/
 │   │   └── agent_config.yaml # version: 0.1.0 | path: src/config/agent_config.yaml
 │   └── roi_screenshots/  # ROI screenshot samples
 ├── run_start.py          # version: 0.2.0 | path: run_start.py  
-├── data_recorder.py      # version: 0.3.0 | path: data_recorder.py  
+├── data_recorder.py      # version: 0.4.0 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.0 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.0 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.1.0 | path: pre_train_data.py
@@ -152,7 +152,7 @@ pyyaml
   - Screen capture separated into `capture_utils.py`.
   - ROI capture and validation logic moved to `roi_capture.py`.
 - **Data Recording & Pretraining**:
-  - `data_recorder.py` allows manual/automatic action logging.
+  - `data_recorder.py` logs frame screenshots, observations and semantic actions.
   - Scripts for behavior cloning from recorded data.
   - Placeholder `agent.py` for PPO model management.
   - `bot_core.py` central bot loop connecting all modules.

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.3.0
+# version: 0.4.0
 # path: data_recorder.py
 
 import pickle
@@ -65,8 +65,9 @@ def _wait_for_event(env):
 def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_path=None):
     env = EveEnv()
     demo_buffer = []
-    os.makedirs('recordings/frames', exist_ok=True)
-    log_path = os.path.join('recordings', 'log.jsonl')
+    demo_dir = os.path.join('logs', 'demonstrations')
+    os.makedirs(demo_dir, exist_ok=True)
+    log_path = os.path.join(demo_dir, 'log.jsonl')
     model = None
     if model_path and os.path.exists(model_path):
         model = PPO.load(model_path, env=env)
@@ -90,13 +91,9 @@ def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_
 
             frame = env.ui.capture()
             ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-            fp = os.path.join('recordings/frames', f"{ts}.png")
+            fp = os.path.join(demo_dir, f"{ts}.png")
             cv2.imwrite(fp, frame)
-            state = {
-                'obs': obs.tolist(),
-                'prev_volume': getattr(env, 'prev_volume', None),
-                'cargo_capacity': getattr(env, 'cargo_capacity', None)
-            }
+            state = env.get_observation()
             log_file.write(json.dumps({'frame': fp, 'action': label, 'state': state}) + "\n")
 
             obs, reward, done, info = env.step(action)

--- a/replay_session.py
+++ b/replay_session.py
@@ -126,7 +126,7 @@ def replay(log_file: str, delay: int = 500, model_path: Optional[str] = None,
 
 def main():
     parser = argparse.ArgumentParser(description="Replay recorded session")
-    parser.add_argument("--log", type=str, default="recordings/log.jsonl",
+    parser.add_argument("--log", type=str, default="logs/demonstrations/log.jsonl",
                         help="Path to log file")
     parser.add_argument("--delay", type=int, default=500,
                         help="Delay between frames in ms")

--- a/src/env.py
+++ b/src/env.py
@@ -131,3 +131,12 @@ class EveEnv(gym.Env):
         img = self.ui.capture()
         text = self.ocr.extract_text(img).lower()
         return ('destroyed' in text) or ('docked' in text)
+
+    def get_observation(self):
+        """Return a dictionary snapshot of the current observation state."""
+        vec = self._get_obs()
+        return {
+            'obs': vec.tolist(),
+            'prev_volume': getattr(self, 'prev_volume', None),
+            'cargo_capacity': getattr(self, 'cargo_capacity', None)
+        }


### PR DESCRIPTION
## Summary
- expand `EveEnv` with `get_observation` helper
- log frame/observation pairs in `data_recorder`
- update default log path in `replay_session`
- document new logging location in README
- bump data recorder version in Scaffold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494e29373883228080ce6e653ef5ad