### PR TITLE
Add hybrid BC preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.4.2 | path: README.md -->
+<!-- version: 0.4.3 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -23,11 +23,14 @@ pytest -q
 python data_recorder.py --manual False
 ```
 
-2. Train the BC model:
+2. Train the BC model (reads the jsonl log and normalizes observations):
 
 ```bash
-python pre_train_data.py --demos demo_buffer.pkl --out bc_model.pt
+python pre_train_data.py --demos logs/demonstrations/log.jsonl --out bc_model.pt
 ```
+
+The loader converts action labels to one-hot vectors and returns
+`[image_tensor, state_tensor]` pairs suitable for a hybrid CNN/MLP model.
 
 3. Fine-tune with PPO (optional `--bc_model`):
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -28,7 +28,7 @@ BAgent/
 ├── data_recorder.py      # version: 0.4.0 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.0 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.0 | path: generate_box_files.py
-├── pre_train_data.py     # version: 0.1.0 | path: pre_train_data.py
+├── pre_train_data.py     # version: 0.2.0 | path: pre_train_data.py
 ├── replay_session.py     # version: 0.2.0 | path: replay_session.py
 ├── add_tesseract_to_path.bat # helper script to set PATH on Windows
 ├── ets.txt               # sample training commands
@@ -38,7 +38,7 @@ BAgent/
 ├── test_env.py           # version: 0.1.1 | path: test_env.py
 ├── tests/                # test suite
 ├── training_texts_dir/   # OCR training data
-└── README.md             # version: 0.4.1 | path: README.md
+└── README.md             # version: 0.4.3 | path: README.md
 ```
 
 ---

--- a/pre_train_data.py
+++ b/pre_train_data.py
@@ -1,30 +1,50 @@
 """Behavior cloning pretraining script."""
 
+# version: 0.2.0 | path: pre_train_data.py
+
 import pickle
 import argparse
 import json
 from typing import Sequence, List, Tuple, Dict
+
+from PIL import Image
+import numpy as np
 
 from src.env import EveEnv
 
 import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
+import torch.nn.functional as F
 
 
 class BCModel(nn.Module):
+    """Simple hybrid CNN + MLP model for behavior cloning."""
+
     def __init__(self, obs_dim: int, n_actions: int):
         super().__init__()
-        self.net = nn.Sequential(
-            nn.Linear(obs_dim, 64),
+        self.cnn = nn.Sequential(
+            nn.Conv2d(3, 8, kernel_size=5, stride=2),
+            nn.ReLU(),
+            nn.Conv2d(8, 16, kernel_size=3, stride=2),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d((4, 4)),
+            nn.Flatten(),
+        )
+        cnn_out = 16 * 4 * 4
+        self.mlp = nn.Sequential(
+            nn.Linear(cnn_out + obs_dim, 64),
             nn.ReLU(),
             nn.Linear(64, 64),
             nn.ReLU(),
             nn.Linear(64, n_actions),
         )
 
-    def forward(self, x):
-        return self.net(x)
+    def forward(self, inputs):
+        img, state = inputs
+        feats = self.cnn(img)
+        combined = torch.cat([feats, state], dim=1)
+        return self.mlp(combined)
 
 
 def _label_mapping(env: EveEnv) -> Dict[str, int]:
@@ -40,53 +60,84 @@ def _label_mapping(env: EveEnv) -> Dict[str, int]:
     return mapping
 
 
-def _load_jsonl(path: str, env: EveEnv) -> Sequence[Tuple[List[float], int]]:
+def _load_jsonl(path: str, env: EveEnv) -> Sequence[Tuple[str, List[float], int]]:
+    """Load data from a jsonl demonstration file.
+
+    Returns a list of ``(frame_path, obs, action_idx)`` tuples.
+    """
     mapping = _label_mapping(env)
     data = []
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         for line in f:
+            if not line.strip():
+                continue
             entry = json.loads(line)
-            label = entry.get('action')
+            label = entry.get("action")
             if label in mapping:
                 action = mapping[label]
-            elif label and '_' in label:
+            elif label and "_" in label:
                 try:
-                    action = int(label.split('_')[-1])
+                    action = int(label.split("_")[-1])
                 except ValueError:
                     continue
             else:
                 continue
-            obs = entry.get('state', {}).get('obs')
-            if obs is not None:
-                data.append((obs, action))
+            obs = entry.get("state", {}).get("obs")
+            frame = entry.get("frame")
+            if obs is not None and frame:
+                data.append((frame, obs, action))
     return data
 
 
-def _load_data(demo_file: str) -> Sequence[Tuple[List[float], int]]:
+def _load_data(demo_file: str) -> Sequence[Tuple[str, List[float], int]]:
+    """Load demonstration data from jsonl or pickle."""
     env = EveEnv()
-    if demo_file.endswith('.jsonl'):
+    if demo_file.endswith(".jsonl"):
         return _load_jsonl(demo_file, env)
-    with open(demo_file, 'rb') as f:
+    with open(demo_file, "rb") as f:
         return pickle.load(f)
 
 
 def train_bc(demo_file: str, output: str, epochs: int = 5, batch_size: int = 32):
-    data: Sequence = _load_data(demo_file)
+    """Train a simple behavior cloning model from demonstration data."""
+    data = _load_data(demo_file)
 
-    obs = torch.tensor([d[0] for d in data], dtype=torch.float32)
-    actions = torch.tensor([d[1] for d in data], dtype=torch.long)
+    # Load images and states
+    images = []
+    states = []
+    actions_idx = []
+    for frame, obs, act in data:
+        img = Image.open(frame).convert("RGB").resize((64, 64))
+        img_arr = np.array(img, dtype=np.float32) / 255.0
+        img_tensor = torch.from_numpy(img_arr).permute(2, 0, 1)
+        images.append(img_tensor)
+        states.append(torch.tensor(obs, dtype=torch.float32))
+        actions_idx.append(act)
 
-    dataset = TensorDataset(obs, actions)
+    images = torch.stack(images)
+    states = torch.stack(states)
+    actions_idx = torch.tensor(actions_idx, dtype=torch.long)
+
+    # Normalize observations
+    mean = states.mean(0)
+    std = states.std(0) + 1e-8
+    states = (states - mean) / std
+
+    n_actions = actions_idx.max().item() + 1
+    actions = F.one_hot(actions_idx, num_classes=n_actions).float()
+
+    dataset = TensorDataset(images, states, actions)
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
-    model = BCModel(obs.shape[1], actions.max().item() + 1)
+    model = BCModel(states.shape[1], n_actions)
     opt = optim.Adam(model.parameters(), lr=1e-3)
     loss_fn = nn.CrossEntropyLoss()
 
     for epoch in range(epochs):
-        for b_obs, b_act in loader:
-            logits = model(b_obs)
-            loss = loss_fn(logits, b_act)
+        for b_img, b_state, b_act in loader:
+            logits = model([b_img, b_state])
+            target = torch.argmax(b_act, dim=1)
+            loss = loss_fn(logits, target)
             opt.zero_grad()
             loss.backward()
             opt.step()


### PR DESCRIPTION
## Summary
- extend pre_train_data.py with hybrid [image,state] tensors
- normalize observations and one-hot encode actions
- document updated pipeline in README
- bump file versions in scaffold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684950c19c188322b78de83b0ab3fbdf