### PR TITLE
Update docs and wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.5.4 | path: README.md -->
+<!-- version: 0.5.5 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -14,7 +14,8 @@ The repository ships with `sitecustomize.py`, which automatically adds
 `roi_capture.py`) mirror their counterparts under `src/` for easy imports.
 These top-level modules simply re-export everything from the `src` package so
 imports work whether you run scripts from the repository root or from the
-`tests/` directory.
+`tests/` directory. They also provide lightweight fallbacks for optional
+dependencies like OpenCV when running the unit tests.
 
 Run tests with:
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,7 +1,7 @@
 # EVE Online Bot Project Scaffold
 
-> version: 0.5.1
-> updated: Added thin wrapper modules for easy imports and documented file versioning
+> version: 0.5.2
+> updated: Added cv2 fallback in `roi_capture.py` and clarified wrapper behaviour
 
 ---
 
@@ -26,7 +26,7 @@ BAgent/
 │   │   └── agent_config.yaml # version: 0.1.0 | path: src/config/agent_config.yaml
 │   └── roi_screenshots/  # ROI screenshot samples
 ├── env.py               # version: 0.1.0 | path: env.py
-├── roi_capture.py       # version: 0.1.1 | path: roi_capture.py
+├── roi_capture.py       # version: 0.1.2 | path: roi_capture.py
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.2 | path: run_start.py

--- a/roi_capture.py
+++ b/roi_capture.py
@@ -1,7 +1,13 @@
 # roi_capture.py
-# version: 0.1.1
+# version: 0.1.2
 # path: roi_capture.py
-"""Thin wrapper for src.roi_capture with graceful fallback."""
+"""Thin wrapper for :mod:`src.roi_capture` with graceful fallback.
+
+Provides basic stubs for ``cv2`` so that unit tests can run without the
+real OpenCV dependency installed.  The stubs implement just enough
+functionality for ``capture_utils`` and ``roi_capture`` to import
+successfully.
+"""
 
 import importlib, types, sys
 
@@ -11,15 +17,63 @@ if 'cv2' not in sys.modules:
     cv2_stub.imshow = lambda *a, **k: None
     cv2_stub.waitKey = lambda *a, **k: None
     cv2_stub.destroyAllWindows = lambda *a, **k: None
+    cv2_stub.cvtColor = lambda img, flag=None: img
+    cv2_stub.COLOR_BGRA2BGR = 0
     sys.modules['cv2'] = cv2_stub
 
 try:
     module = importlib.import_module('src.roi_capture')
     globals().update(module.__dict__)
-    module.RegionHandler = globals().get('RegionHandler', module.RegionHandler)
-    module.capture_region_tool = globals().get('capture_region_tool', module.capture_region_tool) if 'capture_region_tool' in globals() else module.capture_region_tool
-except Exception:  # pragma: no cover - dependencies missing
+
+    # Minimal wrapper so tests can override RegionHandler and capture_screen
     def capture_region_tool():
+        RH = globals().get('RegionHandler', module.RegionHandler)
+        cs = globals().get('capture_screen', module.capture_screen)
+        rh = RH()
+        print("ROI Capture Tool started. Type 'help' for commands.")
+        module.print_menu()
+        while True:
+            cmd = input("roi> ").strip().split()
+            if not cmd:
+                continue
+            op = cmd[0]
+            if op == 'help':
+                module.print_menu()
+            elif op == 'capture' and len(cmd)==2:
+                name = cmd[1]
+                rt = input("Enter region type (click/text/detect): ").strip()
+                print(f"Select region '{name}' then press ENTER...")
+                abs_coords = cs(select_region=True)
+                if abs_coords is None:
+                    print("Cancelled.")
+                    continue
+                if isinstance(abs_coords, np.ndarray):
+                    abs_coords = tuple(abs_coords.flatten().astype(int))
+                rh.add_region(name, abs_coords, rt)
+                print(f"Region '{name}' captured.")
+            elif op == 'list':
+                regs = rh.list_regions()
+                if not regs:
+                    print("No regions defined.")
+                else:
+                    print("Defined regions:")
+                    for n in regs:
+                        coords = rh.load(n)
+                        rtype = rh.regions.get(n, {}).get('type', 'unknown')
+                        print(f"  • {n}: {coords} (type: {rtype})")
+            elif op == 'delete' and len(cmd)==2:
+                rh.delete_region(cmd[1])
+                print(f"Region '{cmd[1]}' deleted.")
+            elif op == 'preview' and len(cmd)==2:
+                if not rh.preview_region(cmd[1]):
+                    print("Region not found.")
+            elif op == 'exit':
+                break
+            else:
+                print("Unknown command. Type 'help' for commands.")
+    RegionHandler = module.RegionHandler
+except Exception:  # pragma: no cover - dependencies missing
+    def capture_region_tool(*args, **kwargs):
         raise RuntimeError('roi_capture requires optional dependencies')
 
     class RegionHandler:


### PR DESCRIPTION
## Summary
- document fallback wrappers and bump version tags
- update scaffold with new wrapper details
- extend `roi_capture.py` fallback to include a minimal capture CLI and cv2 stubs

## Testing
- `pytest -q` *(fails: FileNotFoundError in `test_capture_cli`)*

------
https://chatgpt.com/codex/tasks/task_e_6849d216add88322b799bfb4b42707c3