### PR TITLE
Fix agent sys.path import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.5.6 | path: README.md -->
+<!-- version: 0.5.7 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -18,7 +18,9 @@ imports work whether you run scripts from the repository root or from the
 dependencies like OpenCV when running the unit tests.
 
 Modules such as `roi_capture` now insert their folder into `sys.path` before
-importing sibling modules. This prevents `ModuleNotFoundError` when the
+importing sibling modules. Similarly, `src/agent.py` adds the project root to
+`sys.path` so it can import `pre_train_data` even when scripts are launched from
+within the `src` directory. These tweaks prevent `ModuleNotFoundError` when the
 wrappers are used without modifying `PYTHONPATH`.
 
 Run tests with:

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,7 +1,8 @@
 # EVE Online Bot Project Scaffold
 
-> version: 0.5.3
-> updated: Ensured `roi_capture` inserts its directory into `sys.path` before importing siblings
+> version: 0.5.4
+> updated: `agent` now appends the project root to `sys.path` for importing
+> `pre_train_data`, in addition to `roi_capture` inserting its own folder.
 
 ---
 
@@ -11,7 +12,7 @@ BAgent/
 ├── src/
 │   ├── bot_core.py       # version: 0.6.0 | path: src/bot_core.py
 │   ├── env.py            # version: 0.4.5 | path: src/env.py
-│   ├── agent.py          # version: 0.5.0 | path: src/agent.py
+│   ├── agent.py          # version: 0.5.1 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.5 | path: src/ocr.py
 │   ├── cv.py             # version: 0.3.3 | path: src/cv.py
 │   ├── ui.py             # version: 0.3.7 | path: src/ui.py  
@@ -50,7 +51,7 @@ BAgent/
 │   └── test_replay_session.py     # version: 0.1.0 | path: tests/test_replay_session.py
 ├── sitecustomize.py      # version: 0.1.0 | path: sitecustomize.py
 ├── training_texts_dir/   # OCR training data
-└── README.md             # version: 0.5.4 | path: README.md
+└── README.md             # version: 0.5.7 | path: README.md
 ```
 
 ---
@@ -74,6 +75,8 @@ BAgent/
   - `replay_correction.py` allows correcting actions during replay and marks samples with higher weight.
   - `pre_train_data.py` now standardizes observations with `StandardScaler`
     and creates validation splits via `train_test_split` before training the PyTorch model.
+  - `agent.py` prepends the project root to `sys.path` so `pre_train_data` can
+    be imported when running modules from the `src` directory.
 - **Testing & Validation:**
   - `test_env.py` for quick ROI and env step sanity checks.
   - `test_gui_cli_integration.py` exercises ROI/UI functionality via the GUI and CLI.

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,7 +1,8 @@
-# version: 0.5.0
+# version: 0.5.1
 # path: src/agent.py
 
 import os
+import sys
 import json
 import yaml
 import joblib
@@ -11,6 +12,9 @@ import pyautogui
 from stable_baselines3 import PPO
 import torch
 import torch.nn as nn
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 from pre_train_data import BCModel, train_bc as bc_train
 
 from capture_utils import capture_screen


### PR DESCRIPTION
## Summary
- fix ModuleNotFoundError by adding repo root to `sys.path` in `src/agent.py`
- document the new behaviour in README
- update Scaffold with version bumps and mention of the new import fix

## Testing
- `pip install numpy pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e3171b548322b8c568db6d901e14