### PR TITLE
Fix imports and document path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.5.7 | path: README.md -->
+<!-- version: 0.5.8 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -22,6 +22,10 @@ importing sibling modules. Similarly, `src/agent.py` adds the project root to
 `sys.path` so it can import `pre_train_data` even when scripts are launched from
 within the `src` directory. These tweaks prevent `ModuleNotFoundError` when the
 wrappers are used without modifying `PYTHONPATH`.
+Recent updates switched intra-package imports to explicit relative form
+(`from .ocr import OcrEngine`, etc.). If you encounter `ModuleNotFoundError`
+for modules like `ocr`, ensure you're running commands from the repository root
+or that `src/` is on `PYTHONPATH`.
 
 Run tests with:
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,8 +1,7 @@
 # EVE Online Bot Project Scaffold
 
-> version: 0.5.4
-> updated: `agent` now appends the project root to `sys.path` for importing
-> `pre_train_data`, in addition to `roi_capture` inserting its own folder.
+> version: 0.5.5
+> updated: imports within `src` now use explicit relative form so modules like `ocr` load correctly when running scripts from the repository root.
 
 ---
 
@@ -10,18 +9,18 @@
 ```
 BAgent/
 ├── src/
-│   ├── bot_core.py       # version: 0.6.0 | path: src/bot_core.py
-│   ├── env.py            # version: 0.4.5 | path: src/env.py
-│   ├── agent.py          # version: 0.5.1 | path: src/agent.py
+│   ├── bot_core.py       # version: 0.6.1 | path: src/bot_core.py
+│   ├── env.py            # version: 0.4.6 | path: src/env.py
+│   ├── agent.py          # version: 0.5.2 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.5 | path: src/ocr.py
-│   ├── cv.py             # version: 0.3.3 | path: src/cv.py
-│   ├── ui.py             # version: 0.3.7 | path: src/ui.py  
+│   ├── cv.py             # version: 0.3.4 | path: src/cv.py
+│   ├── ui.py             # version: 0.3.8 | path: src/ui.py
 │   ├── capture_utils.py  # version: 0.8.1 | path: src/capture_utils.py
 │   ├── logger.py         # version: 0.1.0 | path: src/logger.py
 │   ├── roi_capture.py    # version: 0.2.5 | path: src/roi_capture.py
-│   ├── mining_actions.py # version: 0.1.1 | path: src/mining_actions.py
+│   ├── mining_actions.py # version: 0.1.2 | path: src/mining_actions.py
 │   ├── ocr_finetune.py   # version: 0.1.0 | path: src/ocr_finetune.py
-│   ├── roi_live_overlay.py # version: 0.3.0 | path: src/roi_live_overlay.py
+│   ├── roi_live_overlay.py # version: 0.3.1 | path: src/roi_live_overlay.py
 │   ├── state_machine.py  # version: 0.2.0 | path: src/state_machine.py
 │   ├── config/
 │   │   └── agent_config.yaml # version: 0.1.0 | path: src/config/agent_config.yaml
@@ -51,7 +50,7 @@ BAgent/
 │   └── test_replay_session.py     # version: 0.1.0 | path: tests/test_replay_session.py
 ├── sitecustomize.py      # version: 0.1.0 | path: sitecustomize.py
 ├── training_texts_dir/   # OCR training data
-└── README.md             # version: 0.5.7 | path: README.md
+└── README.md             # version: 0.5.8 | path: README.md
 ```
 
 ---
@@ -77,6 +76,8 @@ BAgent/
     and creates validation splits via `train_test_split` before training the PyTorch model.
   - `agent.py` prepends the project root to `sys.path` so `pre_train_data` can
     be imported when running modules from the `src` directory.
+  - Imports within `src` are now relative (e.g. `from .ocr import OcrEngine`) to
+    avoid `ModuleNotFoundError` when executing scripts directly.
 - **Testing & Validation:**
   - `test_env.py` for quick ROI and env step sanity checks.
   - `test_gui_cli_integration.py` exercises ROI/UI functionality via the GUI and CLI.

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,4 +1,4 @@
-# version: 0.5.1
+# version: 0.5.2
 # path: src/agent.py
 
 import os
@@ -15,12 +15,12 @@ import torch.nn as nn
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
-from pre_train_data import BCModel, train_bc as bc_train
+from .pre_train_data import BCModel, train_bc as bc_train
 
-from capture_utils import capture_screen
-from roi_capture import RegionHandler
-from state_machine import State, Event
-from env import EveEnv
+from .capture_utils import capture_screen
+from .roi_capture import RegionHandler
+from .state_machine import State, Event
+from .env import EveEnv
 
 
 class BCPolicy(nn.Module):

--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -1,4 +1,4 @@
-# version: 0.6.0
+# version: 0.6.1
 # path: src/bot_core.py
 
 import sys
@@ -12,14 +12,14 @@ from logger import get_logger
 
 logger = get_logger(__name__)
 
-from roi_capture import RegionHandler
-from ocr import OcrEngine
-from cv import CvEngine
-from state_machine import FSM, Event
-from mining_actions import MiningActions
-from env import EveEnv
-from agent import AIPilot
-from ui import Ui
+from .roi_capture import RegionHandler
+from .ocr import OcrEngine
+from .cv import CvEngine
+from .state_machine import FSM, Event
+from .mining_actions import MiningActions
+from .env import EveEnv
+from .agent import AIPilot
+from .ui import Ui
 
 class EveBot:
     def __init__(self, model_path=None):

--- a/src/cv.py
+++ b/src/cv.py
@@ -1,4 +1,4 @@
-# version: 0.3.3
+# version: 0.3.4
 # path: src/cv.py
 
 import cv2
@@ -7,7 +7,7 @@ from PIL import Image
 import threading
 import queue
 import difflib
-from ocr import OcrEngine
+from .ocr import OcrEngine
 
 class CvEngine:
     def __init__(self, ocr=None):

--- a/src/env.py
+++ b/src/env.py
@@ -1,4 +1,4 @@
-# version: 0.4.5
+# version: 0.4.6
 # path: src/env.py
 
 try:
@@ -26,10 +26,10 @@ except Exception:  # pragma: no cover - allow import without gym
 
     spaces = types.SimpleNamespace(Discrete=DummyDiscrete, Box=DummyBox)
 import numpy as np
-from ocr import OcrEngine
-from cv import CvEngine
-from ui import Ui
-from roi_capture import RegionHandler
+from .ocr import OcrEngine
+from .cv import CvEngine
+from .ui import Ui
+from .roi_capture import RegionHandler
 
 class EveEnv(gym.Env):
     def __init__(self, reward_config=None):

--- a/src/mining_actions.py
+++ b/src/mining_actions.py
@@ -1,4 +1,4 @@
-# version: 0.1.1
+# version: 0.1.2
 # path: src/mining_actions.py
 """High level mining routine utilities.
 
@@ -15,11 +15,11 @@ import time
 import yaml
 import pyautogui
 
-from ui import Ui
-from roi_capture import RegionHandler
-from ocr import OcrEngine
-from cv import CvEngine
-import capture_utils
+from .ui import Ui
+from .roi_capture import RegionHandler
+from .ocr import OcrEngine
+from .cv import CvEngine
+from . import capture_utils
 
 
 class MiningActions:

--- a/src/roi_live_overlay.py
+++ b/src/roi_live_overlay.py
@@ -1,10 +1,10 @@
-# version: 0.3.0
+# version: 0.3.1
 # path: src/roi_live_overlay.py
 
 import cv2
 import time
-from roi_capture import RegionHandler
-from capture_utils import capture_screen
+from .roi_capture import RegionHandler
+from .capture_utils import capture_screen
 
 def draw_overlay(rois, screen):
     for name, (x1, y1, x2, y2) in rois.items():

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,4 +1,4 @@
-# version: 0.3.7
+# version: 0.3.8
 # path: src/ui.py
 
 import pyautogui
@@ -6,8 +6,8 @@ import numpy as np
 import time
 import threading
 import random
-from capture_utils import capture_screen
-from roi_capture import RegionHandler
+from .capture_utils import capture_screen
+from .roi_capture import RegionHandler
 
 class Ui:
     def __init__(self, capture_region=None):


### PR DESCRIPTION
## Summary
- use relative imports inside `src` modules to avoid missing module errors
- document new import style in README
- update Scaffold with new version info
- bump version headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aa231e7d48322b79b272ac1f64f46