### PR TITLE
Add package init and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.5.8 | path: README.md -->
+<!-- version: 0.5.9 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -25,7 +25,9 @@ wrappers are used without modifying `PYTHONPATH`.
 Recent updates switched intra-package imports to explicit relative form
 (`from .ocr import OcrEngine`, etc.). If you encounter `ModuleNotFoundError`
 for modules like `ocr`, ensure you're running commands from the repository root
-or that `src/` is on `PYTHONPATH`.
+or that `src/` is on `PYTHONPATH`. The directory now ships with a minimal
+`src/__init__.py` so the package is recognized even on Python versions that do
+not support implicit namespace packages.
 
 Run tests with:
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,7 +1,7 @@
 # EVE Online Bot Project Scaffold
 
-> version: 0.5.5
-> updated: imports within `src` now use explicit relative form so modules like `ocr` load correctly when running scripts from the repository root.
+> version: 0.5.6
+> updated: added `src/__init__.py` and noted relative imports. The package now loads correctly across Python versions.
 
 ---
 
@@ -9,6 +9,7 @@
 ```
 BAgent/
 ├── src/
+│   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.6.1 | path: src/bot_core.py
 │   ├── env.py            # version: 0.4.6 | path: src/env.py
 │   ├── agent.py          # version: 0.5.2 | path: src/agent.py
@@ -50,7 +51,7 @@ BAgent/
 │   └── test_replay_session.py     # version: 0.1.0 | path: tests/test_replay_session.py
 ├── sitecustomize.py      # version: 0.1.0 | path: sitecustomize.py
 ├── training_texts_dir/   # OCR training data
-└── README.md             # version: 0.5.8 | path: README.md
+└── README.md             # version: 0.5.9 | path: README.md
 ```
 
 ---

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+# version: 0.1.0
+# path: src/__init__.py
+"""BAgent src package initializer."""
+


### PR DESCRIPTION
## Summary
- add `src/__init__.py` so the src package resolves on older Python versions
- update README with new package info
- document the new file in Scaffold

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aa3888fd883229e291c3e0cfec41c