### PR TITLE
Improve usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-<!-- version: 0.6.0 | path: README.md -->
+<!-- version: 0.7.0 | path: README.md -->
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
 
@@ -33,6 +33,36 @@ Run tests with:
 
 ```bash
 pytest -q
+```
+
+## Quick Start
+
+Clone the repository and install the required packages:
+
+```bash
+git clone <repo-url>
+cd BAgent
+pip install -r requirements.txt
+```
+
+Record demonstrations with `data_recorder.py` (use `--manual True` to capture
+your own actions or `--manual False` for automated playback). Logs are written
+to `logs/demonstrations/` by default:
+
+```bash
+python data_recorder.py --manual True --out logs/demonstrations/log.jsonl
+```
+
+Train a behavior cloning model from the recorded file:
+
+```bash
+python pre_train_data.py --demos logs/demonstrations/log.jsonl --out bc_model.pt
+```
+
+Launch reinforcement learning or inference using `run_start.py`:
+
+```bash
+python run_start.py --train --bc_model bc_model.pt --timesteps 50000
 ```
 
 ### Debug Logging
@@ -94,6 +124,22 @@ pilot = AIPilot()
 pilot.train_bc_from_data('logs/demonstrations/log.jsonl', 'bc_clf.joblib')
 action_idx = pilot.load_and_predict({'obs': [0]*pilot.env.observation_space.shape[0]})
 ```
+
+### Using `data_recorder.py`
+
+The recorder listens for mouse clicks and key presses while the EVE window is
+active. Each event is mapped to an action from the environment's action space
+and written to `logs/demonstrations/log.jsonl` along with a screenshot. Use the
+`--manual` flag to switch between interactive collection (`True`) and automated
+replay (`False`). The output file can then be fed directly to the training
+scripts.
+
+### Using `run_start.py`
+
+`run_start.py` acts as the main entry point for training or running the agent.
+Passing `--train` starts a PPO training loop, optionally initializing the policy
+from a behavior cloning checkpoint via `--bc_model`. Without `--train` the
+script loads the latest model under `logs/ppo/` and runs an evaluation episode.
 
 ### Running BC Inference
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,6 +1,6 @@
 # EVE Online Bot Project Scaffold
 
-> version: 0.5.7
+> version: 0.5.8
 > updated: use relative logger imports and bump versions accordingly.
 
 ---
@@ -30,8 +30,8 @@ BAgent/
 ├── roi_capture.py       # version: 0.1.2 | path: roi_capture.py
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
-├── run_start.py          # version: 0.3.2 | path: run_start.py
-├── data_recorder.py      # version: 0.4.0 | path: data_recorder.py
+├── run_start.py          # version: 0.3.3 | path: run_start.py
+├── data_recorder.py      # version: 0.4.1 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
@@ -51,7 +51,7 @@ BAgent/
 │   └── test_replay_session.py     # version: 0.1.0 | path: tests/test_replay_session.py
 ├── sitecustomize.py      # version: 0.1.0 | path: sitecustomize.py
 ├── training_texts_dir/   # OCR training data
-└── README.md             # version: 0.6.0 | path: README.md
+└── README.md             # version: 0.7.0 | path: README.md
 ```
 
 ---

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.4.0
+# version: 0.4.1
 # path: data_recorder.py
 
 import pickle

--- a/run_start.py
+++ b/run_start.py
@@ -1,5 +1,5 @@
 # run_start.py
-# version: 0.3.2
+# version: 0.3.3
 # path: run_start.py
 
 import os


### PR DESCRIPTION
## Summary
- explain how to quickly clone the repo and run the recorder
- expand README with data_recorder/run_start sections
- bump file versions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aaf7ef22c832280edc15e568acff6