### PR TITLE
Remove end listener in data_recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
+<!-- version: 0.2 | path: README.md -->
 # BAgent
-.2 | path: README.md -->
 
 
 A toolkit for automating EVE Online interactions. The project includes a Gym environment, UI automation modules, and utilities for OCR and computer vision.
@@ -133,6 +133,7 @@ The recorder listens for mouse clicks and key presses while the EVE window is
 active. Each event is mapped to an action from the environment's action space
 and written to `logs/demonstrations/log.jsonl` along with a screenshot. Pass
 `--manual` to collect your own actions or omit the flag to record automated
+playback. Press **End** at any time to stop recording early.
 
 
 ### Using `run_start.py`

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -29,7 +29,7 @@ BAgent/
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.3 | path: run_start.py
-├── data_recorder.py      # version: 0.4.2 | path: data_recorder.py
+├── data_recorder.py      # version: 0.4.3 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.4.2
+# version: 0.4.3
 # path: data_recorder.py
 
 import pickle
@@ -86,18 +86,6 @@ def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_
     obs = env.reset()
     stop_event = Event()
 
-    def on_end_press(key):
-        try:
-            name = key.char.lower()
-        except AttributeError:
-            name = key.name.lower()
-        if name == 'end':
-            stop_event.set()
-            return False
-
-    end_listener = keyboard.Listener(on_press=on_end_press)
-    end_listener.start()
-
     with open(log_path, 'a') as log_file:
         for i in range(num_samples):
             if stop_event.is_set():
@@ -131,7 +119,6 @@ def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_
             if done:
                 obs = env.reset()
 
-    end_listener.stop()
     with open(filename, 'wb') as f:
         pickle.dump(demo_buffer, f)
     print(f"Data recording complete. Saved to {filename}")


### PR DESCRIPTION
## Summary
- rely solely on `_wait_for_event` and `stop_event` to end recording
- update README data recorder instructions
- update file version metadata and scaffold entry

## Testing
- `pip install numpy pyyaml -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae2b285208322a66c7298ef942ade