### PR TITLE
Fix data recorder observation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.3.0
+# version: 0.3.1
 # path: README.md
 
 
@@ -136,6 +136,9 @@ active. Each event is mapped to an action from the environment's action space
 and written to `logs/demonstrations/log_<timestamp>.jsonl` by default. Pass
 `--log` to override the file path and `--manual` to collect your own actions;
 omit `--manual` for automated playback.
+
+As of version 0.4.4 the recorder stores the pre-action observation in the
+pickled buffer so training from `demo_buffer.pkl` matches the JSONL log.
 
 
 ### Using `run_start.py`

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -6,7 +6,7 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.2.0 | path: README.md
+├── README.md           # version: 0.3.1 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.6.2 | path: src/bot_core.py
@@ -30,7 +30,7 @@ BAgent/
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.3 | path: run_start.py
-├── data_recorder.py      # version: 0.4.3 | path: data_recorder.py
+├── data_recorder.py      # version: 0.4.4 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
@@ -176,8 +176,9 @@ pyyaml
   - Screen capture separated into `capture_utils.py`.
   - ROI capture and validation logic moved to `roi_capture.py`.
 - **Data Recording & Pretraining**:
-  - `data_recorder.py` logs frame screenshots, observations and semantic actions.
-  - Recording can be terminated early with the **End** key.
+- `data_recorder.py` logs frame screenshots, observations and semantic actions.
+- Recording can be terminated early with the **End** key.
+  - The pickled buffer now stores the observation before the action is executed.
   - Scripts for behavior cloning from recorded data.
   - `agent.py` includes BC training and inference helpers.
   - `bot_core.py` central bot loop connecting all modules.

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.4.3
+# version: 0.4.4
 # path: data_recorder.py
 
 import pickle
@@ -115,8 +115,9 @@ def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True, model_
             state = env.get_observation()
             log_file.write(json.dumps({'frame': fp, 'action': label, 'state': state}) + "\n")
 
-            obs, reward, done, info = env.step(action)
-            demo_buffer.append((obs, action))
+            next_obs, reward, done, info = env.step(action)
+            demo_buffer.append((state['obs'], action))
+            obs = next_obs
             print(f"Recorded: Step={i+1}, Action={label}, Reward={reward}")
             if done:
                 obs = env.reset()


### PR DESCRIPTION
## Summary
- ensure `data_recorder` logs the observation before each action
- document the new behaviour in the README
- update scaffold versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeb38f7c88322b1519d4a181f7014