### PR TITLE
Add window title argument for data recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.3.2
+# version: 0.3.3
 # path: README.md
 
 
@@ -50,9 +50,9 @@ pip install -r requirements.txt
 
 Record demonstrations with `data_recorder.py`. Pass `--manual` to capture your
 own actions; omit the flag for automatic playback. Use `--log` to specify the
-JSONL output (defaults to `logs/demonstrations/log_<timestamp>.jsonl`). If your
-EVE client runs under a different window title, supply `--window-title` (default
-`"EVE - CitizenZero"`).
+JSONL output (defaults to `logs/demonstrations/log_<timestamp>.jsonl`). The
+window title is built from `src/config/pilot_name.txt`; override it with
+`--window-title`.
 
 ```bash
 python data_recorder.py --manual --log logs/demonstrations/my_log.jsonl \
@@ -138,8 +138,8 @@ The recorder listens for mouse clicks and key presses while the EVE window is
 active. Each event is mapped to an action from the environment's action space
 and written to `logs/demonstrations/log_<timestamp>.jsonl` by default. Pass
 `--log` to override the file path and `--manual` to collect your own actions;
-omit `--manual` for automated playback. Use `--window-title` if the EVE window
-title differs from the default.
+omit `--manual` for automated playback. The default title comes from
+`src/config/pilot_name.txt`; pass `--window-title` to override.
 
 As of version 0.4.4 the recorder stores the pre-action observation in the
 pickled buffer so training from `demo_buffer.pkl` matches the JSONL log.

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -6,15 +6,15 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.3.2 | path: README.md
+├── README.md           # version: 0.3.3 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.6.2 | path: src/bot_core.py
-│   ├── env.py            # version: 0.4.8 | path: src/env.py
+│   ├── env.py            # version: 0.4.9 | path: src/env.py
 │   ├── agent.py          # version: 0.5.2 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.7 | path: src/ocr.py
 │   ├── cv.py             # version: 0.3.5 | path: src/cv.py
-│   ├── ui.py             # version: 0.3.9 | path: src/ui.py
+│   ├── ui.py             # version: 0.4.0 | path: src/ui.py
 │   ├── capture_utils.py  # version: 0.8.2 | path: src/capture_utils.py
 │   ├── logger.py         # version: 0.1.0 | path: src/logger.py
 │   ├── roi_capture.py    # version: 0.2.5 | path: src/roi_capture.py
@@ -23,14 +23,15 @@ BAgent/
 │   ├── roi_live_overlay.py # version: 0.3.1 | path: src/roi_live_overlay.py
 │   ├── state_machine.py  # version: 0.2.0 | path: src/state_machine.py
 │   ├── config/
-│   │   └── agent_config.yaml # version: 0.1.0 | path: src/config/agent_config.yaml
+│   │   ├── agent_config.yaml # version: 0.1.0 | path: src/config/agent_config.yaml
+│   │   └── pilot_name.txt    # version: 0.1.0 | path: src/config/pilot_name.txt
 │   └── roi_screenshots/  # ROI screenshot samples
 ├── env.py               # version: 0.1.0 | path: env.py
 ├── roi_capture.py       # version: 0.1.2 | path: roi_capture.py
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.3 | path: run_start.py
-├── data_recorder.py      # version: 0.4.5 | path: data_recorder.py
+├── data_recorder.py      # version: 0.4.6 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
@@ -65,7 +66,7 @@ BAgent/
 - **Data & Training Pipeline:**
   - `data_recorder.py` supports manual/automatic demo collection and can be
     stopped with the **End** key.
-  - Optional `--window-title` selects the EVE window (default `"EVE - CitizenZero"`).
+  - Optional `--window-title` selects the EVE window (default is read from `src/config/pilot_name.txt`).
   - Tools for dataset generation and preprocessing.
   - CLI entry via `run_start.py` and PySide6 GUI support.
   - `agent.py` provides BC training (`train_bc_from_data`) and inference (`load_and_predict`).

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.4.5
+# version: 0.4.6
 # path: data_recorder.py
 
 import pickle
@@ -10,6 +10,7 @@ import cv2
 from pynput import mouse, keyboard
 from threading import Event
 from src.env import EveEnv
+from src.config import get_window_title
 from stable_baselines3 import PPO
 
 
@@ -72,7 +73,9 @@ def _wait_for_event(env, stop_event=None):
 
 
 def record_data(filename='demo_buffer.pkl', num_samples=500, manual=True,
-                model_path=None, log_path=None, window_title="EVE - CitizenZero"):
+                model_path=None, log_path=None, window_title=None):
+    if window_title is None:
+        window_title = get_window_title()
     env = EveEnv(window_title=window_title)
     demo_buffer = []
     demo_dir = os.path.join('logs', 'demonstrations')
@@ -138,7 +141,8 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, default=None)
     parser.add_argument("--log", type=str, default=None,
                         help="Path to JSONL log file")
-    parser.add_argument("--window-title", type=str, default="EVE - CitizenZero",
+    parser.add_argument("--window-title", type=str,
+                        default=get_window_title(),
                         help="Game window title to capture")
     args = parser.parse_args()
 

--- a/src/capture_utils.py
+++ b/src/capture_utils.py
@@ -1,4 +1,4 @@
-# version: 0.8.2
+# version: 0.8.3
 # path: src/capture_utils.py
 
 import cv2
@@ -36,12 +36,20 @@ def get_window_rect(title: str):
     return (rect.left, rect.top, rect.right, rect.bottom), hwnd
 
 
-def capture_screen(select_region=False, window_title="EVE - CitizenZero"):
+def capture_screen(select_region=False, window_title=None):
     """
     Capture a window using PrintWindow (safest GDI method for layered content).
     Works best when EVE is not fullscreen-exclusive.
     """
     global _first_foreground
+
+    if window_title is None:
+        try:
+            from .config import get_window_title
+        except Exception:  # pragma: no cover - fallback for direct execution
+            from config import get_window_title
+
+        window_title = get_window_title()
 
     if win32gui is None:
         # headless fallback for tests
@@ -124,7 +132,9 @@ def capture_screen(select_region=False, window_title="EVE - CitizenZero"):
 
 # --- Test directly ---
 if __name__ == "__main__":
-    frame = capture_screen(window_title="EVE - CitizenZero")
+    from .config import get_window_title
+
+    frame = capture_screen(window_title=get_window_title())
     if frame is not None:
         cv2.imshow("PrintWindow Capture", frame)
         cv2.waitKey(0)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,34 @@
+# version: 0.1.0
+# path: src/config/__init__.py
+
+"""Utility helpers for configuration files."""
+
+import os
+
+
+def _read_first_value(path: str, default: str) -> str:
+    """Return the first non-comment line from ``path`` or ``default``."""
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    return line
+    except Exception:
+        pass
+    return default
+
+
+def get_pilot_name() -> str:
+    """Retrieve the configured pilot name."""
+
+    fname = os.path.join(os.path.dirname(__file__), "pilot_name.txt")
+    return _read_first_value(fname, "CitizenZero")
+
+
+def get_window_title() -> str:
+    """Return the default EVE window title."""
+
+    return f"EVE - {get_pilot_name()}"
+

--- a/src/config/pilot_name.txt
+++ b/src/config/pilot_name.txt
@@ -1,0 +1,4 @@
+# version: 0.1.0
+# path: src/config/pilot_name.txt
+CitizenZero
+

--- a/src/env.py
+++ b/src/env.py
@@ -1,4 +1,4 @@
-# version: 0.4.8
+# version: 0.4.9
 # path: src/env.py
 
 try:
@@ -51,10 +51,13 @@ except Exception:  # pragma: no cover - allow tests without OpenCV
 
 from .ui import Ui
 from .roi_capture import RegionHandler
+from .config import get_window_title
 
 
 class EveEnv(gym.Env):
-    def __init__(self, reward_config=None, window_title="EVE - CitizenZero"):
+    def __init__(self, reward_config=None, window_title=None):
+        if window_title is None:
+            window_title = get_window_title()
         super(EveEnv, self).__init__()
         self.ocr = OcrEngine()
         try:

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,4 +1,4 @@
-# version: 0.3.9
+# version: 0.4.0
 # path: src/ui.py
 
 import pyautogui
@@ -8,9 +8,12 @@ import threading
 import random
 from .capture_utils import capture_screen
 from .roi_capture import RegionHandler
+from .config import get_window_title
 
 class Ui:
-    def __init__(self, capture_region=None, window_title="EVE - CitizenZero"):
+    def __init__(self, capture_region=None, window_title=None):
+        if window_title is None:
+            window_title = get_window_title()
         self.capture_region = capture_region
         self.window_title = window_title
         self.region_handler = RegionHandler()


### PR DESCRIPTION
## Summary
- allow EveEnv/Ui to receive a window title
- expose `--window-title` option in `data_recorder.py`
- document the argument in README and Scaffold

## Testing
- `pip install numpy pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af055c25c83228818644d86d41abf