### PR TITLE
Handle capture failures in data recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.3.4
+# version: 0.3.5
 # path: README.md
 
 
@@ -146,6 +146,10 @@ omit `--manual` for automated playback. The default title comes from
 
 As of version 0.4.4 the recorder stores the pre-action observation in the
 pickled buffer so training from `demo_buffer.pkl` matches the JSONL log.
+
+Frame captures are now validated. If `env.ui.capture()` returns `None`,
+the step is skipped and a warning is logged. After five consecutive
+failures recording aborts to prevent empty data.
 
 
 ### Using `run_start.py`

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -6,7 +6,7 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.3.4 | path: README.md
+├── README.md           # version: 0.3.5 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.6.2 | path: src/bot_core.py
@@ -31,7 +31,7 @@ BAgent/
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.3 | path: run_start.py
-├── data_recorder.py      # version: 0.4.6 | path: data_recorder.py
+├── data_recorder.py      # version: 0.4.7 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
@@ -179,6 +179,8 @@ pyyaml
   - ROI capture and validation logic moved to `roi_capture.py`.
 - **Data Recording & Pretraining**:
 - `data_recorder.py` logs frame screenshots, observations and semantic actions.
+- Recording skips steps when `env.ui.capture()` returns `None` and aborts after
+  repeated failures.
 - Recording can be terminated early with the **End** key.
   - The pickled buffer now stores the observation before the action is executed.
   - Scripts for behavior cloning from recorded data.


### PR DESCRIPTION
## Summary
- validate frames captured in data_recorder
- log warning and abort after repeated failures
- document new behaviour in README
- bump versions in Scaffold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af53bd1788322a030178f79414da5