### PR TITLE
Improve capture_utils fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.3.5
+# version: 0.3.6
 # path: README.md
 
 
@@ -33,7 +33,9 @@ or that `src/` is on `PYTHONPATH`. The directory now ships with a minimal
 not support implicit namespace packages.
 
 `Ui.capture` now always captures the full window and crops to the active
-region if one is loaded.
+region if one is loaded. Screen capture falls back to `pyautogui` or
+`ImageGrab` if `PrintWindow` fails, with a log entry describing the
+method used.
 
 Run tests with:
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -6,7 +6,7 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.3.5 | path: README.md
+├── README.md           # version: 0.3.6 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.6.2 | path: src/bot_core.py
@@ -14,8 +14,8 @@ BAgent/
 │   ├── agent.py          # version: 0.5.2 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.7 | path: src/ocr.py
 │   ├── cv.py             # version: 0.3.5 | path: src/cv.py
-│   ├── ui.py             # version: 0.4.1 | path: src/ui.py
-│   ├── capture_utils.py  # version: 0.8.2 | path: src/capture_utils.py
+│   ├── ui.py             # version: 0.4.2 | path: src/ui.py
+│   ├── capture_utils.py  # version: 0.8.4 | path: src/capture_utils.py
 │   ├── logger.py         # version: 0.1.0 | path: src/logger.py
 │   ├── roi_capture.py    # version: 0.2.5 | path: src/roi_capture.py
 │   ├── mining_actions.py # version: 0.1.2 | path: src/mining_actions.py
@@ -31,7 +31,7 @@ BAgent/
 ├── bot_core.py          # version: 0.1.0 | path: bot_core.py
 #   └─ thin wrappers re-exporting the real modules under src/
 ├── run_start.py          # version: 0.3.3 | path: run_start.py
-├── data_recorder.py      # version: 0.4.7 | path: data_recorder.py
+├── data_recorder.py      # version: 0.4.8 | path: data_recorder.py
 ├── export_ocr_samples.py # version: 0.1.3 | path: export_ocr_samples.py
 ├── generate_box_files.py # version: 0.1.1 | path: generate_box_files.py
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
@@ -176,6 +176,8 @@ pyyaml
   - List and delete ROI functionality.
 - **Modularization**:
   - Screen capture separated into `capture_utils.py`.
+  - `capture_screen` now falls back to standard screenshot methods if
+    `PrintWindow` fails, logging which method succeeded.
   - ROI capture and validation logic moved to `roi_capture.py`.
 - **Data Recording & Pretraining**:
 - `data_recorder.py` logs frame screenshots, observations and semantic actions.

--- a/data_recorder.py
+++ b/data_recorder.py
@@ -1,4 +1,4 @@
-# version: 0.4.7
+# version: 0.4.8
 # path: data_recorder.py
 
 import pickle

--- a/src/capture_utils.py
+++ b/src/capture_utils.py
@@ -1,4 +1,4 @@
-# version: 0.8.3
+# version: 0.8.4
 # path: src/capture_utils.py
 
 import cv2
@@ -39,7 +39,9 @@ def get_window_rect(title: str):
 def capture_screen(select_region=False, window_title=None):
     """
     Capture a window using PrintWindow (safest GDI method for layered content).
-    Works best when EVE is not fullscreen-exclusive.
+    Falls back to `pyautogui.screenshot()` or Pillow's `ImageGrab.grab()` if
+    PrintWindow fails or returns a white image. Works best when EVE is not
+    fullscreen-exclusive.
     """
     global _first_foreground
 
@@ -95,15 +97,24 @@ def capture_screen(select_region=False, window_title=None):
     bmp.CreateCompatibleBitmap(mfc_dc, width, height)
     save_dc.SelectObject(bmp)
 
-    # Try PrintWindow
-    result = ctypes.windll.user32.PrintWindow(hwnd, save_dc.GetSafeHdc(), 0)
-    if result != 1:
-        logger.warning("[Capture] PrintWindow failed. Screen may be black.")
-        return None
+    img_bgr = None
+    used_method = "PrintWindow"
 
-    bmp_info = bmp.GetInfo()
-    bmp_str = bmp.GetBitmapBits(True)
-    img = np.frombuffer(bmp_str, dtype="uint8").reshape((height, width, 4))
+    try:
+        result = ctypes.windll.user32.PrintWindow(hwnd, save_dc.GetSafeHdc(), 0)
+    except Exception as e:
+        logger.warning(f"[Capture] PrintWindow error: {e}")
+        result = 0
+
+    if result == 1:
+        bmp_str = bmp.GetBitmapBits(True)
+        img = np.frombuffer(bmp_str, dtype="uint8").reshape((height, width, 4))
+        img_bgr = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+        if np.mean(img_bgr) > 250:
+            logger.warning("[Capture] PrintWindow returned white image.")
+            img_bgr = None
+    else:
+        logger.warning("[Capture] PrintWindow failed.")
 
     # Cleanup
     win32gui.DeleteObject(bmp.GetHandle())
@@ -111,7 +122,24 @@ def capture_screen(select_region=False, window_title=None):
     mfc_dc.DeleteDC()
     win32gui.ReleaseDC(hwnd, hwnd_dc)
 
-    img_bgr = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+    if img_bgr is None:
+        try:
+            import pyautogui
+            screenshot = pyautogui.screenshot(region=(left, top, width, height))
+            img_bgr = cv2.cvtColor(np.array(screenshot), cv2.COLOR_RGB2BGR)
+            used_method = "pyautogui"
+        except Exception as e:
+            logger.warning(f"[Capture] pyautogui.screenshot failed: {e}")
+            try:
+                from PIL import ImageGrab
+                screenshot = ImageGrab.grab(bbox=(left, top, right, bottom))
+                img_bgr = cv2.cvtColor(np.array(screenshot), cv2.COLOR_RGB2BGR)
+                used_method = "ImageGrab"
+            except Exception as e:
+                logger.error(f"[Capture] ImageGrab failed: {e}")
+                return None
+
+    logger.info(f"[Capture] captured via {used_method}")
 
     if select_region:
         roi = cv2.selectROI(

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,4 +1,4 @@
-# version: 0.4.1
+# version: 0.4.2
 # path: src/ui.py
 
 import pyautogui


### PR DESCRIPTION
## Summary
- fall back to `pyautogui.screenshot` or PIL `ImageGrab.grab` when `PrintWindow` fails
- log which capture method succeeded
- bump version comments for `capture_utils`, `ui.py`, `data_recorder.py`
- document new fallback behaviour in README and Scaffold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c679a16f483228177c6beea2e74e6