### PR TITLE
Expose mining telemetry in perception payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.5.0
+# version: 0.6.0
 # path: README.md
 
 
@@ -104,7 +104,11 @@ python run_start.py --train --bc_model bc_model.pt --timesteps 50000
 EveBot can delegate planning to a local LM Studio instance. When LLM planning
 is enabled the bot gathers the current observation vector, OCR text snippet,
 and the most recent YOLO detections and posts the structured payload to
-`src/llm_client.py`. The LM Studio endpoint (default
+`src/llm_client.py`. The perception blob now includes a `status` section that
+summarises live mining telemetry—cargo hold percentage, which module slots are
+cycling, whether a target is locked, whether hostiles were detected on the
+current frame, and the last environment reward (all values are clipped for
+JSON safety). The LM Studio endpoint (default
 `http://localhost:1234/v1/chat/completions`) is configurable in
 `src/config/agent_config.yaml` under the `llm` section. The response must be a
 JSON object with an `actions` list; each entry is forwarded to

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,5 +1,5 @@
 # EVE Online Bot Project Scaffold
-# version: 0.6.0
+# version: 0.7.0
 # path: Scaffold.md
 
 ---
@@ -7,10 +7,10 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.5.0 | path: README.md
+├── README.md           # version: 0.6.0 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
-│   ├── bot_core.py       # version: 0.7.0 | path: src/bot_core.py
+│   ├── bot_core.py       # version: 0.8.0 | path: src/bot_core.py
 │   ├── env.py            # version: 0.5.0 | path: src/env.py
 │   ├── agent.py          # version: 0.5.2 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.7 | path: src/ocr.py
@@ -78,8 +78,9 @@ BAgent/
   - Template matching remains available as a fallback when the ONNX model is
     missing.
 - **LLM Planning:**
-  - `src/llm_client.py` posts perception snapshots (observations, OCR, YOLO detections)
-    to a local LM Studio server and parses JSON action plans.
+  - `src/llm_client.py` posts perception snapshots (observations, OCR, YOLO detections,
+    and a structured status block with cargo %, module activity, hostiles, target lock,
+    and recent rewards) to a local LM Studio server and parses JSON action plans.
   - `EveBot` can execute LLM-provided actions via the GUI (`--llm-planning` CLI
     flag or the `llm.enabled` configuration) and falls back to the mining
     routine if the request fails.


### PR DESCRIPTION
## Summary
- refactor the mining routine into reusable scan helpers and persist the last reward for reuse
- extend the LLM perception payload with a clipped status block covering cargo, module activity, hostiles, target lock, and recent rewards
- document the richer telemetry schema and bump README/Scaffold versions for operators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da648d5e388322ba5370f38c66c5a0