### PR TITLE
Document UI command schema and surface capabilities to the planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.6.0
+# version: 0.7.0
 # path: README.md
 
 
@@ -108,12 +108,21 @@ and the most recent YOLO detections and posts the structured payload to
 summarises live mining telemetry—cargo hold percentage, which module slots are
 cycling, whether a target is locked, whether hostiles were detected on the
 current frame, and the last environment reward (all values are clipped for
-JSON safety). The LM Studio endpoint (default
-`http://localhost:1234/v1/chat/completions`) is configurable in
-`src/config/agent_config.yaml` under the `llm` section. The response must be a
-JSON object with an `actions` list; each entry is forwarded to
-`Ui.execute`, which now understands clicks by coordinate or ROI, hotkeys,
-typing, drags, scrolls, sleeps, and nested `sequence` groups.
+JSON safety). A new `capabilities` section mirrors the UI affordances so the
+planner knows which commands and ROI identifiers are valid. The LM Studio
+endpoint (default `http://localhost:1234/v1/chat/completions`) is configurable
+in `src/config/agent_config.yaml` under the `llm` section.
+
+`DEFAULT_SYSTEM_PROMPT` now inlines a concise schema harvested directly from
+`Ui.execute`, describing every supported command (click, move, drag, hotkey,
+type, scroll, sleep, switch_region, sequence, noop, etc.) and their parameters.
+The perception payload's `capabilities.commands` mirrors this schema in JSON so
+the LLM can validate its own output. Custom planners can override the prompt by
+setting `llm.system_prompt` in the config file; any override will replace the
+default while still receiving the same capability metadata. Responses must be a
+JSON object with an `actions` array—each entry is forwarded verbatim to
+`Ui.execute`, and helper fields like `sleep_after` remain supported for
+post-action pauses.
 
 1. Start LM Studio with a chat-completion model and enable streaming or JSON
    replies.

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,5 +1,5 @@
 # EVE Online Bot Project Scaffold
-# version: 0.7.0
+# version: 0.8.0
 # path: Scaffold.md
 
 ---
@@ -7,16 +7,16 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.6.0 | path: README.md
+├── README.md           # version: 0.7.0 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
-│   ├── bot_core.py       # version: 0.8.0 | path: src/bot_core.py
+│   ├── bot_core.py       # version: 0.9.0 | path: src/bot_core.py
 │   ├── env.py            # version: 0.5.0 | path: src/env.py
 │   ├── agent.py          # version: 0.5.2 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.7 | path: src/ocr.py
 │   ├── cv.py             # version: 0.4.0 | path: src/cv.py
 │   ├── detector.py       # version: 0.1.0 | path: src/detector.py
-│   ├── ui.py             # version: 0.5.0 | path: src/ui.py
+│   ├── ui.py             # version: 0.6.0 | path: src/ui.py
 │   ├── capture_utils.py  # version: 0.8.5 | path: src/capture_utils.py
 │   ├── logger.py         # version: 0.1.0 | path: src/logger.py
 │   ├── roi_capture.py    # version: 0.2.5 | path: src/roi_capture.py
@@ -24,7 +24,7 @@ BAgent/
 │   ├── ocr_finetune.py   # version: 0.1.0 | path: src/ocr_finetune.py
 │   ├── roi_live_overlay.py # version: 0.3.1 | path: src/roi_live_overlay.py
 │   ├── state_machine.py  # version: 0.2.0 | path: src/state_machine.py
-│   ├── llm_client.py     # version: 0.1.0 | path: src/llm_client.py
+│   ├── llm_client.py     # version: 0.2.0 | path: src/llm_client.py
 │   ├── config/
 │   │   ├── agent_config.yaml # version: 0.3.0 | path: src/config/agent_config.yaml
 │   │   └── pilot_name.txt    # version: 0.1.0 | path: src/config/pilot_name.txt
@@ -81,6 +81,10 @@ BAgent/
   - `src/llm_client.py` posts perception snapshots (observations, OCR, YOLO detections,
     and a structured status block with cargo %, module activity, hostiles, target lock,
     and recent rewards) to a local LM Studio server and parses JSON action plans.
+  - Perception now bundles a `capabilities` payload enumerating valid ROI identifiers,
+    hotkey names, and the UI command schema so planners can align actions with
+    supported affordances. The default system prompt embeds the same schema and may
+    be overridden via `llm.system_prompt`.
   - `EveBot` can execute LLM-provided actions via the GUI (`--llm-planning` CLI
     flag or the `llm.enabled` configuration) and falls back to the mining
     routine if the request fails.

--- a/src/bot_core.py
+++ b/src/bot_core.py
@@ -1,4 +1,4 @@
-# version: 0.8.0
+# version: 0.9.0
 # path: src/bot_core.py
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from .state_machine import FSM, Event
 from .mining_actions import MiningActions
 from .env import EveEnv
 from .agent import AIPilot
-from .ui import Ui
+from .ui import Ui, COMMAND_SCHEMA
 from .llm_client import LMStudioClient
 
 
@@ -280,6 +280,15 @@ class EveBot:
             },
             "reward": self._clip_numeric(self._last_reward) if self._last_reward is not None else None,
         }
+        capabilities = {
+            "commands": COMMAND_SCHEMA,
+            "rois": {
+                "click": list(getattr(self.env, "click_rois", []) or []),
+                "text": list(getattr(self.env, "text_rois", []) or []),
+                "detect": list(getattr(self.env, "detect_rois", []) or []),
+            },
+            "keys": list(getattr(self.env, "key_actions", []) or []),
+        }
         return {
             "timestamp": time.time(),
             "mode": self.mode,
@@ -288,6 +297,7 @@ class EveBot:
             "ocr_excerpt": ocr_excerpt[:500],
             "detections": formatted,
             "status": perception_status,
+            "capabilities": capabilities,
         }
 
     def _execute_plan(self, plan: List[Dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
- capture the supported UI command schema in `src/ui.py` and expose a helper for documentation
- expand the default LM Studio system prompt with the schema summary and guidance on using perception capabilities
- attach a capabilities section with commands and ROI identifiers to the LLM perception payload and refresh README/Scaffold guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da676ecba4832285c7fe0a87fc531a