### PR TITLE
Fix missing OcrEngine import for AIPilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.7.0
+# version: 0.7.1
 # path: README.md
 
 
@@ -24,7 +24,9 @@ Modules such as `roi_capture` now insert their folder into `sys.path` before
 importing sibling modules. Similarly, `src/agent.py` adds the project root to
 `sys.path` so it can import `pre_train_data` even when scripts are launched from
 within the `src` directory. These tweaks prevent `ModuleNotFoundError` when the
-wrappers are used without modifying `PYTHONPATH`.
+wrappers are used without modifying `PYTHONPATH`. The `AIPilot` class now
+imports `OcrEngine` directly from `src/ocr.py`, ensuring the default OCR
+provider is available without requiring callers to pass an instance explicitly.
 Recent updates switched intra-package imports to explicit relative form
 (`from .ocr import OcrEngine`, etc.). If you encounter `ModuleNotFoundError`
 for modules like `ocr`, ensure you're running commands from the repository root

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -7,12 +7,12 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.7.0 | path: README.md
+├── README.md           # version: 0.7.1 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.9.0 | path: src/bot_core.py
 │   ├── env.py            # version: 0.5.0 | path: src/env.py
-│   ├── agent.py          # version: 0.5.2 | path: src/agent.py
+│   ├── agent.py          # version: 0.5.3 | path: src/agent.py
 │   ├── ocr.py            # version: 0.3.7 | path: src/ocr.py
 │   ├── cv.py             # version: 0.4.0 | path: src/cv.py
 │   ├── detector.py       # version: 0.1.0 | path: src/detector.py

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,4 +1,4 @@
-# version: 0.5.2
+# version: 0.5.3
 # path: src/agent.py
 
 import os
@@ -21,6 +21,7 @@ from .capture_utils import capture_screen
 from .roi_capture import RegionHandler
 from .state_machine import State, Event
 from .env import EveEnv
+from .ocr import OcrEngine
 
 
 class BCPolicy(nn.Module):


### PR DESCRIPTION
## Summary
- import `OcrEngine` in `AIPilot` so the default OCR dependency is available
- document the change in the README and bump the associated version metadata
- refresh the scaffold listing to match the updated README and agent versions

## Testing
- `python - <<'PY' ...` (instantiates `AIPilot` with lightweight stubs)

------
https://chatgpt.com/codex/tasks/task_e_68da768a7fc883228c57027b80074db0