### PR TITLE
Add log search and tagging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BAgent
-# version: 0.7.1
+# version: 0.7.2
 # path: README.md
 
 
@@ -292,6 +292,33 @@ If Tesseract is not on your `PATH`, provide the path via `--tesseract-cmd` or
 set the `TESSERACT_CMD` environment variable. Windows users can run
 `add_tesseract_to_path.bat` with administrator rights to add Tesseract to
 `PATH` and set the `TESSERACT_CMD` variable automatically.
+
+## Log Search & Tagging Utilities
+
+Two lightweight helper modules simplify working with demonstration logs and
+metadata outside of the main training pipeline:
+
+- `search.py` exposes `search_in_file` and `search_paths` for filtering JSONL or
+  plain-text logs using substring queries, regular expressions, or custom
+  predicates. Optional `fields` selectors enable targeting nested JSON keys
+  while keeping the API simple for scripts and notebooks.
+- `tag.py` provides the `TagStore` class for maintaining a stable mapping of log
+  identifiers to tags. Tags are normalised, deduplicated, and stored in a
+  consistent order; persistence helpers (`save`, `load_tag_store`) read and
+  write JSON files under `logs/`.
+
+Example usage:
+
+```python
+from search import search_in_file
+from tag import TagStore
+
+matches = search_in_file("logs/demonstrations/log_20250612_180024.jsonl", "warp")
+store = TagStore()
+for match in matches:
+    store.add(match.entry.get("id", match.line_number), "warp")
+store.save("logs/demonstrations/tags.json")
+```
 
 ### OCR Configuration
 

--- a/Scaffold.md
+++ b/Scaffold.md
@@ -1,5 +1,5 @@
 # EVE Online Bot Project Scaffold
-# version: 0.8.0
+# version: 0.8.1
 # path: Scaffold.md
 
 ---
@@ -7,7 +7,7 @@
 ## Directory Structure
 ```
 BAgent/
-├── README.md           # version: 0.7.1 | path: README.md
+├── README.md           # version: 0.7.2 | path: README.md
 ├── src/
 │   ├── __init__.py       # version: 0.1.0 | path: src/__init__.py
 │   ├── bot_core.py       # version: 0.9.0 | path: src/bot_core.py
@@ -40,6 +40,8 @@ BAgent/
 ├── pre_train_data.py     # version: 0.3.0 | path: pre_train_data.py
 ├── replay_session.py     # version: 0.3.0 | path: replay_session.py
 ├── replay_correction.py     # version: 0.1.0 | path: replay_correction.py
+├── search.py            # version: 0.1.0 | path: search.py
+├── tag.py               # version: 0.1.0 | path: tag.py
 ├── add_tesseract_to_path.bat # helper script to set PATH on Windows
 ├── ets.txt               # sample training commands
 ├── promts.txt            # project prompts and notes
@@ -60,57 +62,11 @@ BAgent/
 
 ## Recent Changes Summary
 
-- **Modularization & Tooling:**
-  - Screen capture (`capture_utils.py`) now prioritizes `mss` window grabs before
-    falling back to `PrintWindow`, `pyautogui`, or `ImageGrab`, with logs noting the
-    chosen method. ROI capture (`roi_capture.py`), GUI in `bot_core.py`.
-  - Dynamic ROI types (click/text/detect) and auto-generated action space in `env.py`.  
-- **Environment Enhancements:**
-  - Dynamic ROI loading, text & detection regions, cargo capacity parsing.
-  - Expanded action set from EVE-Master internal nodes.
-- **Vision Pipeline:**
-  - `CvEngine.detect_elements` now defers to an ONNX-backed YOLOv8 detector
-    (`src/detector.py`), returning bounding boxes and confidences.
-  - `EveEnv` consumes detector class labels (configured via
-    `detector.reward_labels`) for observations and rewards, with
-    per-ROI label overrides in `src/config/agent_config.yaml` and
-    `src/regions.yaml`.
-  - Template matching remains available as a fallback when the ONNX model is
-    missing.
-- **LLM Planning:**
-  - `src/llm_client.py` posts perception snapshots (observations, OCR, YOLO detections,
-    and a structured status block with cargo %, module activity, hostiles, target lock,
-    and recent rewards) to a local LM Studio server and parses JSON action plans.
-  - Perception now bundles a `capabilities` payload enumerating valid ROI identifiers,
-    hotkey names, and the UI command schema so planners can align actions with
-    supported affordances. The default system prompt embeds the same schema and may
-    be overridden via `llm.system_prompt`.
-  - `EveBot` can execute LLM-provided actions via the GUI (`--llm-planning` CLI
-    flag or the `llm.enabled` configuration) and falls back to the mining
-    routine if the request fails.
-  - `Ui.execute` now supports coordinate clicks, drags, hotkeys, typing, and
-    other rich commands under a thread-safe UI lock.
-- **Data & Training Pipeline:**
-  - `data_recorder.py` supports manual/automatic demo collection and can be
-    stopped with the **End** key.
-  - Optional `--window-title` selects the EVE window (default is read from `src/config/pilot_name.txt`).
-  - Tools for dataset generation and preprocessing.
-  - CLI entry via `run_start.py` and PySide6 GUI support. Project dependencies now
-    include `mss` (and `pywin32` for Windows capture fallbacks) via `requirements.txt`.
-  - `agent.py` provides BC training (`train_bc_from_data`) and inference (`load_and_predict`).
-  - `bot_core.py` can run BC models via `--mode bc_inference`.
-  - `replay_session.py` visualizes demonstrations and outputs accuracy and confusion metrics.
-  - `bot_core.py` now supports Auto, Manual and Assistive modes toggled by F1-F3, with F4 confirming suggestions.
-  - `replay_correction.py` allows correcting actions during replay and marks samples with higher weight.
-  - `pre_train_data.py` now standardizes observations with `StandardScaler`
-    and creates validation splits via `train_test_split` before training the PyTorch model.
-  - `agent.py` prepends the project root to `sys.path` so `pre_train_data` can
-    be imported when running modules from the `src` directory.
-  - Imports within `src` are now relative (e.g. `from .ocr import OcrEngine`) to
-    avoid `ModuleNotFoundError` when executing scripts directly.
-- **Testing & Validation:**
-  - `test_env.py` for quick ROI and env step sanity checks.
-  - `test_gui_cli_integration.py` exercises ROI/UI functionality via the GUI and CLI.
+- **Log Tooling:**
+  - Added `search.py` for structured searching across JSONL demonstration logs with
+    substring, regex, or callable predicates and optional nested field selectors.
+  - Introduced `tag.py` with a `TagStore` utility to normalise, deduplicate, and persist
+    metadata tags for recorded sessions.
 
 ---
 

--- a/search.py
+++ b/search.py
@@ -1,0 +1,256 @@
+# version: 0.1.0
+# path: search.py
+"""Utility helpers for searching structured and plain-text log files.
+
+The functions in this module are intentionally lightweight so they can be used
+inside unit tests and ad-hoc scripts alike. They focus on JSON Lines (``.jsonl``)
+inputs because that is the format used for bot demonstrations, yet they fall
+back to simple string processing when a line is not valid JSON. Callers can
+provide plain strings, compiled regular expressions or custom callables as the
+query predicate. Optional ``fields`` allow targeting specific keys inside JSON
+objects (including ``dot.notation`` for nested dictionaries).
+
+Example
+-------
+
+```python
+from search import search_in_file
+
+results = search_in_file("logs/demonstrations/log.jsonl", "warp")
+for match in results:
+    print(match.path, match.line_number, match.entry["action"])
+```
+
+The search helpers return :class:`SearchResult` dataclasses containing the
+parsed entry, the original raw text and metadata such as the source path and
+line number.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any, Callable, Iterable, Iterator, Mapping, Optional, Sequence, Tuple, Union
+
+JsonLike = Mapping[str, Any]
+QueryType = Union[str, re.Pattern[str], Sequence[Union[str, re.Pattern[str]]], Callable[[Any], bool]]
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """Container describing a single match from :func:`search_in_file`.
+
+    Attributes
+    ----------
+    path:
+        Filesystem path to the scanned file.
+    line_number:
+        One-based line number where the match occurred.
+    entry:
+        Parsed representation of the line. JSON objects are returned as dicts;
+        otherwise the raw string is provided.
+    raw_text:
+        The original line text prior to parsing. Useful for displaying context
+        or for working with non-JSON inputs where ``entry`` is identical to the
+        raw string.
+    """
+
+    path: Path
+    line_number: int
+    entry: Any
+    raw_text: str
+
+
+def iter_records(path: Union[str, Path], *, encoding: str = "utf-8", errors: str = "replace") -> Iterator[Tuple[int, str, Any]]:
+    """Yield parsed records from ``path`` one line at a time.
+
+    Parameters
+    ----------
+    path:
+        File system path to scan.
+    encoding / errors:
+        Passed to :func:`Path.open` for decoding the file contents.
+
+    Returns
+    -------
+    Iterator[Tuple[int, str, Any]]
+        Yields ``(line_number, raw_text, entry)`` tuples where ``entry`` is the
+        JSON-decoded object if possible, otherwise the original string.
+    """
+
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Cannot open '{file_path}': file does not exist")
+
+    with file_path.open("r", encoding=encoding, errors=errors) as handle:
+        for line_number, raw_text in enumerate(handle, start=1):
+            stripped = raw_text.rstrip("\n")
+            if not stripped:
+                # Preserve blank lines as empty strings so downstream callers
+                # can decide whether they are interesting.
+                yield line_number, stripped, ""
+                continue
+
+            try:
+                entry = json.loads(stripped)
+            except json.JSONDecodeError:
+                entry = stripped
+            yield line_number, stripped, entry
+
+
+def search_in_file(
+    path: Union[str, Path],
+    query: QueryType,
+    *,
+    fields: Optional[Sequence[str]] = None,
+    case_sensitive: bool = False,
+    limit: Optional[int] = None,
+) -> list[SearchResult]:
+    """Return matches for ``query`` inside a JSONL or plain-text file.
+
+    ``query`` accepts several forms:
+
+    - ``str``: substring search.
+    - ``re.Pattern``: regular expression ``search``.
+    - ``Sequence`` of the above: every element must match the same line.
+    - ``Callable``: predicate receiving the parsed entry; returning ``True``
+      marks the line as a match.
+
+    Parameters
+    ----------
+    path:
+        File to scan.
+    query:
+        Predicate describing what constitutes a match.
+    fields:
+        Optional iterable describing which JSON keys to search. Nested keys can
+        be addressed with ``dot.notation``. When omitted the entire entry (or
+        line) is considered.
+    case_sensitive:
+        When ``False`` (default) searches are performed using :meth:`str.casefold`.
+    limit:
+        Maximum number of matches to return. ``None`` means no limit.
+    """
+
+    matcher = _build_entry_matcher(query, fields=fields, case_sensitive=case_sensitive)
+    results: list[SearchResult] = []
+
+    for line_number, raw_text, entry in iter_records(path):
+        if matcher(entry, raw_text):
+            results.append(SearchResult(path=Path(path), line_number=line_number, entry=entry, raw_text=raw_text))
+            if limit is not None and len(results) >= limit:
+                break
+
+    return results
+
+
+def search_paths(
+    paths: Iterable[Union[str, Path]],
+    query: QueryType,
+    *,
+    fields: Optional[Sequence[str]] = None,
+    case_sensitive: bool = False,
+    limit_per_file: Optional[int] = None,
+) -> list[SearchResult]:
+    """Search across multiple files and return all matching records."""
+
+    collected: list[SearchResult] = []
+    for path in paths:
+        matches = search_in_file(
+            path,
+            query,
+            fields=fields,
+            case_sensitive=case_sensitive,
+            limit=limit_per_file,
+        )
+        collected.extend(matches)
+    return collected
+
+
+def _build_entry_matcher(
+    query: QueryType,
+    *,
+    fields: Optional[Sequence[str]],
+    case_sensitive: bool,
+) -> Callable[[Any, str], bool]:
+    if callable(query) and not isinstance(query, re.Pattern):
+        return lambda entry, raw: bool(query(entry))
+
+    text_matcher = _build_text_matcher(query, case_sensitive=case_sensitive)
+
+    def matcher(entry: Any, raw_text: str) -> bool:
+        searchable = _entry_to_searchable(entry, raw_text, fields)
+        return text_matcher(searchable)
+
+    return matcher
+
+
+def _build_text_matcher(query: QueryType, *, case_sensitive: bool) -> Callable[[str], bool]:
+    if isinstance(query, re.Pattern):
+        pattern = query if case_sensitive or (query.flags & re.IGNORECASE) else re.compile(query.pattern, query.flags | re.IGNORECASE)
+        return lambda value: bool(pattern.search(value))
+
+    if isinstance(query, Sequence) and not isinstance(query, (str, bytes)):
+        sub_matchers = [_build_text_matcher(subquery, case_sensitive=case_sensitive) for subquery in query]
+        return lambda value: all(match(value) for match in sub_matchers)
+
+    if isinstance(query, str):
+        processed = query if case_sensitive else query.casefold()
+        if case_sensitive:
+            return lambda value: processed in value
+        return lambda value: processed in value.casefold()
+
+    raise TypeError("Unsupported query type: expected str, Pattern, Sequence or callable")
+
+
+def _entry_to_searchable(entry: Any, raw_text: str, fields: Optional[Sequence[str]]) -> str:
+    if fields and isinstance(entry, Mapping):
+        values = []
+        for field in fields:
+            value = _extract_field(entry, field)
+            if value is None:
+                continue
+            values.append(_stringify(value))
+        if values:
+            return " ".join(values)
+        # Fall back to raw text when none of the requested fields are present.
+
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, Mapping):
+        return json.dumps(entry, sort_keys=True)
+    return raw_text
+
+
+def _extract_field(entry: JsonLike, dotted_key: str) -> Any:
+    parts = dotted_key.split(".")
+    current: Any = entry
+    for part in parts:
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)) or value is None:
+        return json.dumps(value)
+    if isinstance(value, (list, tuple, set)):
+        return ", ".join(_stringify(item) for item in value)
+    if isinstance(value, Mapping):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+__all__ = [
+    "SearchResult",
+    "iter_records",
+    "search_in_file",
+    "search_paths",
+]
+

--- a/tag.py
+++ b/tag.py
@@ -1,0 +1,168 @@
+# version: 0.1.0
+# path: tag.py
+"""Helpers for managing tag metadata associated with demonstration artefacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Mapping, Sequence, Union
+
+
+def normalize_tag(tag: str) -> str:
+    """Return a canonical representation for ``tag``.
+
+    Whitespace is stripped from both ends and the function ensures the result is
+    not empty. ``ValueError`` is raised for invalid input so that callers can
+    catch the problem explicitly instead of silently storing unusable tags.
+    """
+
+    if not isinstance(tag, str):
+        raise TypeError("Tags must be strings")
+    trimmed = tag.strip()
+    if not trimmed:
+        raise ValueError("Tags must contain at least one non-whitespace character")
+    return trimmed
+
+
+class TagStore:
+    """Maintain a mapping of identifiers to a stable, de-duplicated tag list."""
+
+    def __init__(self, *, case_sensitive: bool = False) -> None:
+        self.case_sensitive = case_sensitive
+        self._data: Dict[str, Dict[str, str]] = {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _normalize_item_id(self, item_id: object) -> str:
+        if isinstance(item_id, str):
+            normalized = item_id.strip()
+        else:
+            normalized = str(item_id)
+        if not normalized:
+            raise ValueError("Item identifiers cannot be empty")
+        return normalized
+
+    def _normalize_tag(self, tag: str) -> tuple[str, str]:
+        canonical = normalize_tag(tag)
+        if not self.case_sensitive:
+            return canonical.casefold(), canonical
+        return canonical, canonical
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    def set(self, item_id: object, tags: Iterable[str]) -> None:
+        normalized_id = self._normalize_item_id(item_id)
+        container: Dict[str, str] = {}
+        for tag in tags:
+            key, canonical = self._normalize_tag(tag)
+            container[key] = canonical
+        if container:
+            self._data[normalized_id] = dict(sorted(container.items(), key=lambda kv: kv[1].casefold()))
+        else:
+            self._data.pop(normalized_id, None)
+
+    def add(self, item_id: object, *tags: str) -> bool:
+        normalized_id = self._normalize_item_id(item_id)
+        if normalized_id not in self._data:
+            self._data[normalized_id] = {}
+        container = self._data[normalized_id]
+        changed = False
+        for tag in tags:
+            key, canonical = self._normalize_tag(tag)
+            if key not in container:
+                container[key] = canonical
+                changed = True
+        if changed:
+            self._data[normalized_id] = dict(sorted(container.items(), key=lambda kv: kv[1].casefold()))
+        return changed
+
+    def remove(self, item_id: object, *tags: str) -> bool:
+        normalized_id = self._normalize_item_id(item_id)
+        if normalized_id not in self._data:
+            return False
+        if not tags:
+            del self._data[normalized_id]
+            return True
+
+        container = self._data[normalized_id]
+        changed = False
+        for tag in tags:
+            key, _ = self._normalize_tag(tag)
+            if key in container:
+                del container[key]
+                changed = True
+
+        if not container:
+            del self._data[normalized_id]
+            return True
+
+        if changed:
+            self._data[normalized_id] = dict(sorted(container.items(), key=lambda kv: kv[1].casefold()))
+        return changed
+
+    # ------------------------------------------------------------------
+    # Queries
+    def get(self, item_id: object) -> list[str]:
+        normalized_id = self._normalize_item_id(item_id)
+        tags = self._data.get(normalized_id, {})
+        return list(tags.values())
+
+    def items(self) -> Iterator[tuple[str, list[str]]]:
+        for item_id, tags in sorted(self._data.items(), key=lambda kv: kv[0]):
+            yield item_id, list(tags.values())
+
+    def find(self, *tags: str, match_all: bool = True) -> list[str]:
+        if not tags:
+            return [item_id for item_id, _ in self.items()]
+
+        normalized_tags = [self._normalize_tag(tag)[0] for tag in tags]
+        matches: list[str] = []
+        for item_id, stored in self._data.items():
+            keys = set(stored.keys())
+            if match_all:
+                if all(tag in keys for tag in normalized_tags):
+                    matches.append(item_id)
+            else:
+                if any(tag in keys for tag in normalized_tags):
+                    matches.append(item_id)
+        return sorted(matches)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def to_dict(self) -> Dict[str, list[str]]:
+        return {item_id: list(tags.values()) for item_id, tags in self._data.items()}
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Sequence[str]], *, case_sensitive: bool = False) -> "TagStore":
+        store = cls(case_sensitive=case_sensitive)
+        for item_id, tags in mapping.items():
+            store.set(item_id, tags)
+        return store
+
+    def save(self, path: Union[str, Path], *, encoding: str = "utf-8") -> None:
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("w", encoding=encoding) as handle:
+            json.dump(self.to_dict(), handle, indent=2, sort_keys=True)
+
+
+def load_tag_store(path: Union[str, Path], *, case_sensitive: bool = False) -> TagStore:
+    file_path = Path(path)
+    if not file_path.exists():
+        return TagStore(case_sensitive=case_sensitive)
+
+    with file_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, Mapping):
+        raise TypeError("Tag file must contain an object mapping identifiers to tags")
+    parsed: Dict[str, Sequence[str]] = {}
+    for key, value in data.items():
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            raise TypeError(f"Tags for '{key}' must be stored as a sequence of strings")
+        parsed[key] = list(value)
+    return TagStore.from_mapping(parsed, case_sensitive=case_sensitive)
+
+
+__all__ = ["TagStore", "normalize_tag", "load_tag_store"]
+


### PR DESCRIPTION
## Summary
- add a reusable `search.py` helper for scanning JSONL or plain-text logs with substring, regex, or callable predicates
- provide a `tag.py` module with a `TagStore` class for normalised tag management and persistence helpers
- document the new tooling and update scaffold metadata and versions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db7795493c8322b54577b04270bceb